### PR TITLE
Modularize HTML structure

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,31 +8,13 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <div class="dock">
-    <span class="title">Tiny Life</span>
-    <button data-toggle="stats">Stats</button>
-    <button data-toggle="actions">Actions</button>
-    <button data-toggle="log">Log</button>
-    <button data-toggle="jobs">Job Hunt</button>
-    <button id="newLife">New Life</button>
-    <span class="muted" style="margin-left:auto">Drag windows • Click to focus • Single-file demo</span>
-  </div>
+  <div id="dock"></div>
 
   <div id="desktop"></div>
 
-  <template id="window-template">
-    <div class="window" style="left: 100px; top: 100px;">
-      <div class="titlebar">
-        <span class="title">Window</span>
-        <div class="controls">
-          <div class="control-btn btn-close" title="Close" aria-label="Close">✕</div>
-        </div>
-      </div>
-      <div class="content"></div>
-    </div>
-  </template>
+  <template id="window-template"></template>
 
-  
-  <script src="script.js"></script>
+
+  <script type="module" src="script.js"></script>
 </body>
 </html>

--- a/partials/dock.html
+++ b/partials/dock.html
@@ -1,0 +1,9 @@
+<div class="dock">
+  <span class="title">Tiny Life</span>
+  <button data-toggle="stats">Stats</button>
+  <button data-toggle="actions">Actions</button>
+  <button data-toggle="log">Log</button>
+  <button data-toggle="jobs">Job Hunt</button>
+  <button id="newLife">New Life</button>
+  <span class="muted" style="margin-left:auto">Drag windows • Click to focus • Single-file demo</span>
+</div>

--- a/partials/window-template.html
+++ b/partials/window-template.html
@@ -1,0 +1,9 @@
+<div class="window" style="left: 100px; top: 100px;">
+  <div class="titlebar">
+    <span class="title">Window</span>
+    <div class="controls">
+      <div class="control-btn btn-close" title="Close" aria-label="Close">✕</div>
+    </div>
+  </div>
+  <div class="content"></div>
+</div>

--- a/script.js
+++ b/script.js
@@ -1,3 +1,12 @@
+    await Promise.all([
+      fetch('partials/dock.html').then(r => r.text()).then(html => {
+        document.getElementById('dock').outerHTML = html;
+      }),
+      fetch('partials/window-template.html').then(r => r.text()).then(html => {
+        document.getElementById('window-template').innerHTML = html;
+      })
+    ]);
+
     // ------------------------------
     // Window Manager
     // ------------------------------


### PR DESCRIPTION
## Summary
- Split dock and window template into separate HTML partials
- Dynamically load partials at runtime with top-level `await`
- Update main HTML to use placeholders and module script

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3accf56b8832a84d6d9007758e3f1