### PR TITLE
Add endscreen life summary

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -1,4 +1,4 @@
-import { game, addLog } from './state.js';
+import { game, addLog, die } from './state.js';
 import { rand, clamp } from './utils.js';
 import { tickJail } from './jail.js';
 import { refreshOpenWindows } from './windowManager.js';
@@ -37,8 +37,7 @@ function randomEvent() {
     game.health = clamp(game.health - rand(2, 6));
   }
   if (rand(1, 1000) === 1) {
-    game.alive = false;
-    addLog('A tragic accident ended your life.');
+    die('A tragic accident ended your life.');
   }
 }
 
@@ -57,8 +56,7 @@ export function ageUp() {
   paySalary();
   randomEvent();
   if (game.health <= 0) {
-    game.alive = false;
-    addLog('Your health reached zero. You passed away.');
+    die('Your health reached zero. You passed away.');
   }
   tickJail();
   refreshOpenWindows();
@@ -163,10 +161,10 @@ export function crime() {
       game.health = clamp(game.health - dmg);
       addLog(`Crime failed: ${c.name}. You were injured (-${dmg} Health).`);
       if (game.health <= 0) {
-        game.alive = false;
-        addLog('You died from your injuries.');
+        die('You died from your injuries.');
       }
     }
   }
   refreshOpenWindows();
 }
+

--- a/components.css
+++ b/components.css
@@ -58,8 +58,26 @@
 
 .badge{ display:inline-block; padding: 2px 8px; border-radius: 999px; border:1px solid var(--stroke); background: rgba(255,255,255,.06); font-size:.8rem; color: var(--muted); }
 
+#endscreen{
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,.9);
+  color: var(--text);
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  padding: 40px;
+  overflow: auto;
+}
+#endscreen.hidden{ display:none; }
+#endscreen h2{ text-align: center; margin-top: 0; }
+#endscreen ul{ list-style: none; padding: 0; max-width: 600px; margin: 0 auto; }
+#endscreen li{ margin: 8px 0; }
+#endscreen time{ color: var(--muted); margin-right: 6px; font-size: .9rem; }
+
 @media (max-width: 640px){
   .window{ width: 86vw; min-width: auto; }
   #desktop{ inset: 92px 0 0 0; }
   .dock{ flex-wrap: wrap; gap: 6px; height: auto; padding-bottom: 10px; }
 }
+

--- a/endscreen.js
+++ b/endscreen.js
@@ -1,0 +1,22 @@
+const screenEl = document.getElementById('endscreen');
+
+export function showEndScreen(game) {
+  screenEl.innerHTML = '';
+  const title = document.createElement('h2');
+  title.textContent = 'Life Story';
+  screenEl.appendChild(title);
+  const list = document.createElement('ul');
+  for (const item of game.log.slice().reverse()) {
+    const li = document.createElement('li');
+    li.innerHTML = `<time>${item.when}</time> ${item.text}`;
+    list.appendChild(li);
+  }
+  screenEl.appendChild(list);
+  screenEl.classList.remove('hidden');
+}
+
+export function hideEndScreen() {
+  screenEl.classList.add('hidden');
+  screenEl.innerHTML = '';
+}
+

--- a/index.html
+++ b/index.html
@@ -16,7 +16,10 @@
 
   <template id="window-template"></template>
 
+  <div id="endscreen" class="hidden"></div>
+
 
   <script type="module" src="script.js"></script>
 </body>
 </html>
+

--- a/state.js
+++ b/state.js
@@ -1,4 +1,5 @@
 import { refreshOpenWindows } from './windowManager.js';
+import { showEndScreen, hideEndScreen } from './endscreen.js';
 
 export const game = {
   year: new Date().getFullYear(),
@@ -22,8 +23,15 @@ export function addLog(text) {
   refreshOpenWindows();
 }
 
+export function die(reason) {
+  game.alive = false;
+  addLog(reason);
+  showEndScreen(game);
+}
+
 export function newLife() {
   const now = new Date().getFullYear();
+  hideEndScreen();
   Object.assign(game, {
     year: now,
     age: 0,
@@ -41,3 +49,4 @@ export function newLife() {
   addLog('You were born. A new life begins.');
   refreshOpenWindows();
 }
+


### PR DESCRIPTION
## Summary
- show a fullscreen endscreen on death that recounts the player's life
- centralize death handling with a `die` helper and log-based life summary

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b3b66b24832a871212a95c87f483