### PR TITLE
Add character overlay with basic identity info

### DIFF
--- a/partials/dock.html
+++ b/partials/dock.html
@@ -1,5 +1,6 @@
 <div class="dock">
   <span class="title">Tiny Life</span>
+  <button data-toggle="character">Character</button>
   <button data-toggle="stats">Stats</button>
   <button data-toggle="actions">Actions</button>
   <button data-toggle="log">Log</button>

--- a/renderers/character.js
+++ b/renderers/character.js
@@ -1,0 +1,12 @@
+import { game } from '../state.js';
+
+export function renderCharacter(container) {
+  const div = document.createElement('div');
+  div.className = 'grid';
+  div.innerHTML = `
+        <div class="row"><strong>Name:</strong> <span>${game.name}</span></div>
+        <div class="row"><strong>Gender:</strong> <span>${game.gender}</span></div>
+        <div class="row"><strong>Location:</strong> <span>${game.city}, ${game.country}</span></div>`;
+  container.appendChild(div);
+}
+

--- a/script.js
+++ b/script.js
@@ -4,6 +4,7 @@ import { renderStats } from './renderers/stats.js';
 import { renderActions } from './renderers/actions.js';
 import { renderLog } from './renderers/log.js';
 import { renderJobs } from './renderers/jobs.js';
+import { renderCharacter } from './renderers/character.js';
 
 async function loadPartials() {
   await Promise.all([
@@ -39,6 +40,9 @@ function openLog() {
 function openJobs() {
   openWindow('jobs', 'Jobs', renderJobs);
 }
+function openCharacter() {
+  openWindow('character', 'Character', renderCharacter);
+}
 
 function toggleStats() {
   toggleWindow('stats', 'Stats', renderStats);
@@ -52,6 +56,9 @@ function toggleLog() {
 function toggleJobs() {
   toggleWindow('jobs', 'Jobs', renderJobs);
 }
+function toggleCharacter() {
+  toggleWindow('character', 'Character', renderCharacter);
+}
 
 document.querySelectorAll('[data-toggle]').forEach(btn => {
   btn.addEventListener('click', () => {
@@ -60,6 +67,7 @@ document.querySelectorAll('[data-toggle]').forEach(btn => {
     if (id === 'actions') toggleActions();
     if (id === 'log') toggleLog();
     if (id === 'jobs') toggleJobs();
+    if (id === 'character') toggleCharacter();
   });
 });
 
@@ -71,3 +79,4 @@ newLife();
 openStats();
 openActions();
 openLog();
+openCharacter();

--- a/state.js
+++ b/state.js
@@ -2,6 +2,14 @@ import { refreshOpenWindows } from './windowManager.js';
 import { rand } from './utils.js';
 import { showEndScreen, hideEndScreen } from './endscreen.js';
 
+const maleNames = ['John', 'Michael', 'David'];
+const femaleNames = ['Sarah', 'Emily', 'Jessica'];
+const locations = [
+  { city: 'New York', country: 'USA' },
+  { city: 'London', country: 'UK' },
+  { city: 'Tokyo', country: 'Japan' }
+];
+
 export const game = {
   year: new Date().getFullYear(),
   age: 0,
@@ -14,6 +22,10 @@ export const game = {
   job: null,
   jobListings: [],
   jobListingsYear: null,
+  gender: '',
+  name: '',
+  city: '',
+  country: '',
   sick: false,
   inJail: false,
   alive: true,
@@ -36,6 +48,12 @@ export function die(reason) {
 export function newLife() {
   const now = new Date().getFullYear();
   hideEndScreen();
+  const gender = rand(0, 1) === 0 ? 'Male' : 'Female';
+  const name =
+    gender === 'Male'
+      ? maleNames[rand(0, maleNames.length - 1)]
+      : femaleNames[rand(0, femaleNames.length - 1)];
+  const { city, country } = locations[rand(0, locations.length - 1)];
   Object.assign(game, {
     year: now,
     age: 0,
@@ -48,6 +66,10 @@ export function newLife() {
     job: null,
     jobListings: [],
     jobListingsYear: null,
+    gender,
+    name,
+    city,
+    country,
     sick: false,
     inJail: false,
     alive: true,


### PR DESCRIPTION
## Summary
- show a new Character window exposing the avatar's name, gender, and home city/country
- extend game state to randomly assign gender, name, and location at the start of each life
- add dock control and wiring to open/toggle the Character overlay

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ba73ce60832abe9a61b85638d574