### PR TITLE
Add scaffolding for activities menu

### DIFF
--- a/activities/accessories.js
+++ b/activities/accessories.js
@@ -1,0 +1,5 @@
+export function renderAccessories(container) {
+  const wrap = document.createElement('div');
+  wrap.textContent = 'Accessories coming soon';
+  container.appendChild(wrap);
+}

--- a/activities/adoption.js
+++ b/activities/adoption.js
@@ -1,0 +1,5 @@
+export function renderAdoption(container) {
+  const wrap = document.createElement('div');
+  wrap.textContent = 'Adoption coming soon';
+  container.appendChild(wrap);
+}

--- a/activities/blackMarket.js
+++ b/activities/blackMarket.js
@@ -1,0 +1,5 @@
+export function renderBlackMarket(container) {
+  const wrap = document.createElement('div');
+  wrap.textContent = 'Black Market coming soon';
+  container.appendChild(wrap);
+}

--- a/activities/casino.js
+++ b/activities/casino.js
@@ -1,0 +1,5 @@
+export function renderCasino(container) {
+  const wrap = document.createElement('div');
+  wrap.textContent = 'Casino coming soon';
+  container.appendChild(wrap);
+}

--- a/activities/commune.js
+++ b/activities/commune.js
@@ -1,0 +1,5 @@
+export function renderCommune(container) {
+  const wrap = document.createElement('div');
+  wrap.textContent = 'Commune coming soon';
+  container.appendChild(wrap);
+}

--- a/activities/crime.js
+++ b/activities/crime.js
@@ -1,0 +1,5 @@
+export function renderCrime(container) {
+  const wrap = document.createElement('div');
+  wrap.textContent = 'Crime coming soon';
+  container.appendChild(wrap);
+}

--- a/activities/doctor.js
+++ b/activities/doctor.js
@@ -1,0 +1,5 @@
+export function renderDoctor(container) {
+  const wrap = document.createElement('div');
+  wrap.textContent = 'Doctor coming soon';
+  container.appendChild(wrap);
+}

--- a/activities/emigrate.js
+++ b/activities/emigrate.js
@@ -1,0 +1,5 @@
+export function renderEmigrate(container) {
+  const wrap = document.createElement('div');
+  wrap.textContent = 'Emigrate coming soon';
+  container.appendChild(wrap);
+}

--- a/activities/fertility.js
+++ b/activities/fertility.js
@@ -1,0 +1,5 @@
+export function renderFertility(container) {
+  const wrap = document.createElement('div');
+  wrap.textContent = 'Fertility coming soon';
+  container.appendChild(wrap);
+}

--- a/activities/gamble.js
+++ b/activities/gamble.js
@@ -1,0 +1,5 @@
+export function renderGamble(container) {
+  const wrap = document.createElement('div');
+  wrap.textContent = 'Gamble coming soon';
+  container.appendChild(wrap);
+}

--- a/activities/horseRacing.js
+++ b/activities/horseRacing.js
@@ -1,0 +1,5 @@
+export function renderHorseRacing(container) {
+  const wrap = document.createElement('div');
+  wrap.textContent = 'Horse Racing coming soon';
+  container.appendChild(wrap);
+}

--- a/activities/identity.js
+++ b/activities/identity.js
@@ -1,0 +1,5 @@
+export function renderIdentity(container) {
+  const wrap = document.createElement('div');
+  wrap.textContent = 'Identity coming soon';
+  container.appendChild(wrap);
+}

--- a/activities/lawsuit.js
+++ b/activities/lawsuit.js
@@ -1,0 +1,5 @@
+export function renderLawsuit(container) {
+  const wrap = document.createElement('div');
+  wrap.textContent = 'Lawsuit coming soon';
+  container.appendChild(wrap);
+}

--- a/activities/licenses.js
+++ b/activities/licenses.js
@@ -1,0 +1,5 @@
+export function renderLicenses(container) {
+  const wrap = document.createElement('div');
+  wrap.textContent = 'Licenses coming soon';
+  container.appendChild(wrap);
+}

--- a/activities/lottery.js
+++ b/activities/lottery.js
@@ -1,0 +1,5 @@
+export function renderLottery(container) {
+  const wrap = document.createElement('div');
+  wrap.textContent = 'Lottery coming soon';
+  container.appendChild(wrap);
+}

--- a/activities/love.js
+++ b/activities/love.js
@@ -1,0 +1,5 @@
+export function renderLove(container) {
+  const wrap = document.createElement('div');
+  wrap.textContent = 'Love coming soon';
+  container.appendChild(wrap);
+}

--- a/activities/luxuryLifestyle.js
+++ b/activities/luxuryLifestyle.js
@@ -1,0 +1,5 @@
+export function renderLuxuryLifestyle(container) {
+  const wrap = document.createElement('div');
+  wrap.textContent = 'Luxury Lifestyle coming soon';
+  container.appendChild(wrap);
+}

--- a/activities/mindAndWork.js
+++ b/activities/mindAndWork.js
@@ -1,0 +1,5 @@
+export function renderMindAndWork(container) {
+  const wrap = document.createElement('div');
+  wrap.textContent = 'Mind & Work coming soon';
+  container.appendChild(wrap);
+}

--- a/activities/movieTheater.js
+++ b/activities/movieTheater.js
@@ -1,0 +1,5 @@
+export function renderMovieTheater(container) {
+  const wrap = document.createElement('div');
+  wrap.textContent = 'Movie Theater coming soon';
+  container.appendChild(wrap);
+}

--- a/activities/nightlife.js
+++ b/activities/nightlife.js
@@ -1,0 +1,5 @@
+export function renderNightlife(container) {
+  const wrap = document.createElement('div');
+  wrap.textContent = 'Nightlife coming soon';
+  container.appendChild(wrap);
+}

--- a/activities/outdoorLifestyle.js
+++ b/activities/outdoorLifestyle.js
@@ -1,0 +1,5 @@
+export function renderOutdoorLifestyle(container) {
+  const wrap = document.createElement('div');
+  wrap.textContent = 'Outdoor Lifestyle coming soon';
+  container.appendChild(wrap);
+}

--- a/activities/pets.js
+++ b/activities/pets.js
@@ -1,0 +1,5 @@
+export function renderPets(container) {
+  const wrap = document.createElement('div');
+  wrap.textContent = 'Pets coming soon';
+  container.appendChild(wrap);
+}

--- a/activities/plasticSurgery.js
+++ b/activities/plasticSurgery.js
@@ -1,0 +1,5 @@
+export function renderPlasticSurgery(container) {
+  const wrap = document.createElement('div');
+  wrap.textContent = 'Plastic Surgery coming soon';
+  container.appendChild(wrap);
+}

--- a/activities/raceTracks.js
+++ b/activities/raceTracks.js
@@ -1,0 +1,5 @@
+export function renderRaceTracks(container) {
+  const wrap = document.createElement('div');
+  wrap.textContent = 'Race Tracks coming soon';
+  container.appendChild(wrap);
+}

--- a/activities/racing.js
+++ b/activities/racing.js
@@ -1,0 +1,5 @@
+export function renderRacing(container) {
+  const wrap = document.createElement('div');
+  wrap.textContent = 'Racing coming soon';
+  container.appendChild(wrap);
+}

--- a/activities/rehab.js
+++ b/activities/rehab.js
@@ -1,0 +1,5 @@
+export function renderRehab(container) {
+  const wrap = document.createElement('div');
+  wrap.textContent = 'Rehab coming soon';
+  container.appendChild(wrap);
+}

--- a/activities/salonAndSpa.js
+++ b/activities/salonAndSpa.js
@@ -1,0 +1,5 @@
+export function renderSalonAndSpa(container) {
+  const wrap = document.createElement('div');
+  wrap.textContent = 'Salon & Spa coming soon';
+  container.appendChild(wrap);
+}

--- a/activities/secretAgent.js
+++ b/activities/secretAgent.js
@@ -1,0 +1,5 @@
+export function renderSecretAgent(container) {
+  const wrap = document.createElement('div');
+  wrap.textContent = 'Secret Agent coming soon';
+  container.appendChild(wrap);
+}

--- a/activities/shopping.js
+++ b/activities/shopping.js
@@ -1,0 +1,5 @@
+export function renderShopping(container) {
+  const wrap = document.createElement('div');
+  wrap.textContent = 'Shopping coming soon';
+  container.appendChild(wrap);
+}

--- a/activities/socialMedia.js
+++ b/activities/socialMedia.js
@@ -1,0 +1,5 @@
+export function renderSocialMedia(container) {
+  const wrap = document.createElement('div');
+  wrap.textContent = 'Social Media coming soon';
+  container.appendChild(wrap);
+}

--- a/activities/vacation.js
+++ b/activities/vacation.js
@@ -1,0 +1,5 @@
+export function renderVacation(container) {
+  const wrap = document.createElement('div');
+  wrap.textContent = 'Vacation coming soon';
+  container.appendChild(wrap);
+}

--- a/activities/willAndTestament.js
+++ b/activities/willAndTestament.js
@@ -1,0 +1,5 @@
+export function renderWillAndTestament(container) {
+  const wrap = document.createElement('div');
+  wrap.textContent = 'Will & Testament coming soon';
+  container.appendChild(wrap);
+}

--- a/activities/zoo.js
+++ b/activities/zoo.js
@@ -1,0 +1,5 @@
+export function renderZoo(container) {
+  const wrap = document.createElement('div');
+  wrap.textContent = 'Zoo coming soon';
+  container.appendChild(wrap);
+}

--- a/activities/zooTrip.js
+++ b/activities/zooTrip.js
@@ -1,0 +1,5 @@
+export function renderZooTrip(container) {
+  const wrap = document.createElement('div');
+  wrap.textContent = 'Zoo Trip coming soon';
+  container.appendChild(wrap);
+}

--- a/partials/dock.html
+++ b/partials/dock.html
@@ -3,6 +3,7 @@
   <button data-toggle="character">Character</button>
   <button data-toggle="stats">Stats</button>
   <button data-toggle="actions">Actions</button>
+  <button data-toggle="activities">Activities</button>
   <button data-toggle="log">Log</button>
   <button data-toggle="jobs">Job Hunt</button>
   <button id="newLife">New Life</button>

--- a/renderers/activities.js
+++ b/renderers/activities.js
@@ -1,0 +1,71 @@
+const ACTIVITIES_CATEGORIES = {
+  'Leisure & Lifestyle': [
+    'Outdoor Lifestyle',
+    'Luxury Lifestyle',
+    'Salon & Spa',
+    'Shopping',
+    'Social Media',
+    'Accessories',
+    'Movie Theater',
+    'Nightlife',
+    'Vacation'
+  ],
+  'Family & Relationships': [
+    'Adoption',
+    'Fertility',
+    'Love',
+    'Pets',
+    'Zoo',
+    'Zoo Trip'
+  ],
+  'Gambling & Racing': [
+    'Casino',
+    'Gamble',
+    'Lottery',
+    'Horse Racing',
+    'Race Tracks',
+    'Racing'
+  ],
+  'Crime & Legal': [
+    'Crime',
+    'Black Market',
+    'Secret Agent',
+    'Identity',
+    'Lawsuit',
+    'Licenses',
+    'Will & Testament'
+  ],
+  'Health & Self-Improvement': [
+    'Doctor',
+    'Plastic Surgery',
+    'Rehab',
+    'Mind & Work'
+  ],
+  'Travel & Community': [
+    'Commune',
+    'Emigrate'
+  ]
+};
+
+export function renderActivities(container) {
+  const wrap = document.createElement('div');
+  wrap.className = 'actions';
+
+  for (const [name, items] of Object.entries(ACTIVITIES_CATEGORIES)) {
+    const head = document.createElement('div');
+    head.className = 'muted';
+    head.style.margin = '8px 0 4px';
+    head.textContent = name;
+    wrap.appendChild(head);
+    for (const item of items) {
+      const btn = document.createElement('button');
+      btn.className = 'btn';
+      btn.textContent = item;
+      btn.disabled = true;
+      wrap.appendChild(btn);
+    }
+  }
+
+  container.appendChild(wrap);
+}
+

--- a/script.js
+++ b/script.js
@@ -5,6 +5,7 @@ import { renderActions } from './renderers/actions.js';
 import { renderLog } from './renderers/log.js';
 import { renderJobs } from './renderers/jobs.js';
 import { renderCharacter } from './renderers/character.js';
+import { renderActivities } from './renderers/activities.js';
 
 async function loadPartials() {
   await Promise.all([
@@ -43,6 +44,9 @@ function openJobs() {
 function openCharacter() {
   openWindow('character', 'Character', renderCharacter);
 }
+function openActivities() {
+  openWindow('activities', 'Activities', renderActivities);
+}
 
 function toggleStats() {
   toggleWindow('stats', 'Stats', renderStats);
@@ -59,6 +63,9 @@ function toggleJobs() {
 function toggleCharacter() {
   toggleWindow('character', 'Character', renderCharacter);
 }
+function toggleActivities() {
+  toggleWindow('activities', 'Activities', renderActivities);
+}
 
 document.querySelectorAll('[data-toggle]').forEach(btn => {
   btn.addEventListener('click', () => {
@@ -68,6 +75,7 @@ document.querySelectorAll('[data-toggle]').forEach(btn => {
     if (id === 'log') toggleLog();
     if (id === 'jobs') toggleJobs();
     if (id === 'character') toggleCharacter();
+    if (id === 'activities') toggleActivities();
   });
 });
 


### PR DESCRIPTION
## Summary
- Centralize activity groups in `ACTIVITIES_CATEGORIES` for the Activities window
- Add placeholder modules for each listed activity for future implementation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3bc4655a0832a97122395aab72024