### PR TITLE
Add restart button to death screen

### DIFF
--- a/components.css
+++ b/components.css
@@ -74,6 +74,10 @@
 #endscreen ul{ list-style: none; padding: 0; max-width: 600px; margin: 0 auto; }
 #endscreen li{ margin: 8px 0; }
 #endscreen time{ color: var(--muted); margin-right: 6px; font-size: .9rem; }
+#endscreen button{
+  align-self: center;
+  margin-top: auto;
+}
 
 @media (max-width: 640px){
   .window{ width: 86vw; min-width: auto; }

--- a/endscreen.js
+++ b/endscreen.js
@@ -1,4 +1,5 @@
 import { StoryNet } from './storyNet.js';
+import { newLife } from './state.js';
 
 const screenEl = document.getElementById('endscreen');
 const net = new StoryNet();
@@ -47,6 +48,12 @@ export function showEndScreen(game) {
     list.appendChild(li);
   }
   screenEl.appendChild(list);
+  const restart = document.createElement('button');
+  restart.textContent = 'Start new life';
+  restart.addEventListener('click', () => {
+    newLife();
+  });
+  screenEl.appendChild(restart);
   screenEl.classList.remove('hidden');
 }
 


### PR DESCRIPTION
## Summary
- add "Start new life" button to end screen and wire it to restart the game
- center restart button at bottom of death screen using flexbox

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3bf451148832a810bcfd418746645