### PR TITLE
Add playable vacation activity

### DIFF
--- a/activities/vacation.js
+++ b/activities/vacation.js
@@ -1,5 +1,29 @@
+import { game, addLog } from '../state.js';
+import { clamp, rand } from '../utils.js';
+import { refreshOpenWindows } from '../windowManager.js';
+
 export function renderVacation(container) {
-  const wrap = document.createElement('div');
-  wrap.textContent = 'Vacation coming soon';
-  container.appendChild(wrap);
+  const head = document.createElement('div');
+  head.className = 'muted';
+  head.textContent = 'Take a relaxing trip to boost your happiness.';
+  container.appendChild(head);
+
+  const btn = document.createElement('button');
+  btn.className = 'btn';
+  btn.textContent = 'Go on Vacation ($500)';
+  btn.addEventListener('click', () => {
+    const cost = 500;
+    if (game.money < cost) {
+      addLog('Vacation costs $500. Not enough money.');
+      refreshOpenWindows();
+      return;
+    }
+    game.money -= cost;
+    const gain = rand(8, 15);
+    game.happiness = clamp(game.happiness + gain);
+    addLog(`You went on a vacation. +${gain} Happiness.`);
+    refreshOpenWindows();
+  });
+
+  container.appendChild(btn);
 }

--- a/renderers/activities.js
+++ b/renderers/activities.js
@@ -1,3 +1,6 @@
+import { openWindow } from '../windowManager.js';
+import { renderVacation } from '../activities/vacation.js';
+
 const ACTIVITIES_CATEGORIES = {
   'Leisure & Lifestyle': [
     'Outdoor Lifestyle',
@@ -62,6 +65,12 @@ export function renderActivities(container) {
       btn.className = 'btn';
       btn.textContent = item;
       btn.disabled = true;
+      if (item === 'Vacation') {
+        btn.disabled = false;
+        btn.addEventListener('click', () => {
+          openWindow('vacation', 'Vacation', renderVacation);
+        });
+      }
       wrap.appendChild(btn);
     }
   }


### PR DESCRIPTION
## Summary
- Enable the Vacation button in Activities and open a dedicated window
- Implement vacation action that costs $500 and boosts happiness while logging the outcome

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3befc8580832a808b0a47c0c608c8