### PR TITLE
feat: add lottery activity

### DIFF
--- a/activities/lottery.js
+++ b/activities/lottery.js
@@ -1,5 +1,41 @@
+import { game, addLog } from '../state.js';
+import { rand, clamp } from '../utils.js';
+import { openWindow, refreshOpenWindows } from '../windowManager.js';
+
+export { openWindow };
+
 export function renderLottery(container) {
   const wrap = document.createElement('div');
-  wrap.textContent = 'Lottery coming soon';
+  const btn = document.createElement('button');
+  btn.className = 'btn';
+  btn.textContent = 'Buy Ticket ($5)';
+  btn.disabled = game.money < 5;
+  btn.addEventListener('click', () => {
+    if (game.money < 5) return;
+    game.money -= 5;
+    const roll = rand(1, 100);
+    let prize = 0;
+    let mood = -2;
+    let msg = 'You bought a lottery ticket but won nothing.';
+    if (roll === 1) {
+      prize = 10000;
+      mood = 20;
+      msg = `Jackpot! You won $${prize.toLocaleString()}.`;
+    } else if (roll <= 5) {
+      prize = 1000;
+      mood = 8;
+      msg = `You won $${prize.toLocaleString()}.`;
+    } else if (roll <= 20) {
+      prize = 100;
+      mood = 3;
+      msg = `You won $${prize}.`;
+    }
+    game.money += prize;
+    game.happiness = clamp(game.happiness + mood);
+    addLog(msg);
+    refreshOpenWindows();
+  });
+  wrap.appendChild(btn);
   container.appendChild(wrap);
 }
+

--- a/renderers/activities.js
+++ b/renderers/activities.js
@@ -1,3 +1,5 @@
+import { openWindow, renderLottery } from '../activities/lottery.js';
+
 const ACTIVITIES_CATEGORIES = {
   'Leisure & Lifestyle': [
     'Outdoor Lifestyle',
@@ -61,7 +63,10 @@ export function renderActivities(container) {
       const btn = document.createElement('button');
       btn.className = 'btn';
       btn.textContent = item;
-      btn.disabled = true;
+      btn.disabled = item !== 'Lottery';
+      if (item === 'Lottery') {
+        btn.addEventListener('click', () => openWindow('lottery', 'Lottery', renderLottery));
+      }
       wrap.appendChild(btn);
     }
   }


### PR DESCRIPTION
## Summary
- enable Lottery button and wire to open its window
- implement lottery game with ticket cost, random prizes, and stat updates

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a3beff4168832aaa0f09deacbf002b