### PR TITLE
feat: add adoption activity

### DIFF
--- a/activities/adoption.js
+++ b/activities/adoption.js
@@ -1,5 +1,38 @@
+import { game, addLog } from '../state.js';
+import { openWindow, refreshOpenWindows } from '../windowManager.js';
+import { faker } from 'https://cdn.jsdelivr.net/npm/@faker-js/faker@8.3.1/+esm';
+
+export { openWindow };
+
+const OPTIONS = [
+  { label: 'Adopt a Baby', cost: 20000, age: 0, happiness: 90 },
+  { label: 'Adopt a Child', cost: 15000, age: 5, happiness: 80 },
+  { label: 'Adopt a Teen', cost: 5000, age: 15, happiness: 70 }
+];
+
 export function renderAdoption(container) {
   const wrap = document.createElement('div');
-  wrap.textContent = 'Adoption coming soon';
+
+  for (const opt of OPTIONS) {
+    const btn = document.createElement('button');
+    btn.className = 'btn block';
+    btn.textContent = `${opt.label} - $${opt.cost.toLocaleString()}`;
+    if (game.money < opt.cost) {
+      btn.disabled = true;
+    }
+    btn.addEventListener('click', () => {
+      if (game.money < opt.cost) return;
+      game.money -= opt.cost;
+      const name = faker.person.firstName();
+      const child = { name, age: opt.age, happiness: opt.happiness };
+      if (!game.children) game.children = [];
+      game.children.push(child);
+      addLog(`You adopted ${name}.`);
+      refreshOpenWindows();
+    });
+    wrap.appendChild(btn);
+  }
+
   container.appendChild(wrap);
 }
+

--- a/renderers/activities.js
+++ b/renderers/activities.js
@@ -1,3 +1,5 @@
+import { openWindow, renderAdoption } from '../activities/adoption.js';
+
 const ACTIVITIES_CATEGORIES = {
   'Leisure & Lifestyle': [
     'Outdoor Lifestyle',
@@ -62,6 +64,12 @@ export function renderActivities(container) {
       btn.className = 'btn';
       btn.textContent = item;
       btn.disabled = true;
+      if (item === 'Adoption') {
+        btn.disabled = false;
+        btn.addEventListener('click', () => {
+          openWindow('adoption', 'Adoption', renderAdoption);
+        });
+      }
       wrap.appendChild(btn);
     }
   }


### PR DESCRIPTION
## Summary
- activate Adoption activity button
- implement adoption options with fees and child state updates

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3bf68c23c832a8c8dfd593ac0b185