### PR TITLE
Enable doctor activity window and add treatment options

### DIFF
--- a/activities/doctor.js
+++ b/activities/doctor.js
@@ -1,5 +1,59 @@
+import { game, addLog } from '../state.js';
+import { clamp, rand } from '../utils.js';
+import { refreshOpenWindows } from '../windowManager.js';
+
 export function renderDoctor(container) {
   const wrap = document.createElement('div');
-  wrap.textContent = 'Doctor coming soon';
+  wrap.className = 'actions';
+
+  const mk = (text, fn, disabled = false) => {
+    const b = document.createElement('button');
+    b.className = 'btn';
+    b.textContent = text;
+    b.disabled = disabled;
+    b.addEventListener('click', fn);
+    return b;
+  };
+
+  wrap.appendChild(
+    mk('Routine Check-Up ($60)', () => {
+      const cost = 60;
+      if (game.money < cost) {
+        addLog(`Doctor visit costs $${cost}. Not enough money.`);
+        return;
+      }
+      game.money -= cost;
+      game.health = clamp(game.health + rand(2, 6));
+      addLog('Routine check-up made you feel better. (+Health)');
+      refreshOpenWindows();
+    })
+  );
+
+  wrap.appendChild(
+    mk(
+      'Treat Illness ($120)',
+      () => {
+        const cost = 120;
+        if (game.money < cost) {
+          addLog(`Doctor visit costs $${cost}. Not enough money.`);
+          return;
+        }
+        game.money -= cost;
+        game.sick = false;
+        game.health = clamp(game.health + rand(6, 12));
+        addLog('The doctor treated your illness. (+Health)');
+        refreshOpenWindows();
+      },
+      !game.sick
+    )
+  );
+
+  const note = document.createElement('div');
+  note.className = 'muted';
+  note.style.marginTop = '8px';
+  note.textContent = 'Doctor visits improve health but cost money.';
+  wrap.appendChild(note);
+
   container.appendChild(wrap);
 }
+

--- a/renderers/activities.js
+++ b/renderers/activities.js
@@ -1,3 +1,6 @@
+import { openWindow } from '../windowManager.js';
+import { renderDoctor } from '../activities/doctor.js';
+
 const ACTIVITIES_CATEGORIES = {
   'Leisure & Lifestyle': [
     'Outdoor Lifestyle',
@@ -61,7 +64,12 @@ export function renderActivities(container) {
       const btn = document.createElement('button');
       btn.className = 'btn';
       btn.textContent = item;
-      btn.disabled = true;
+      if (item === 'Doctor') {
+        btn.disabled = false;
+        btn.addEventListener('click', () => openWindow('doctor', 'Doctor', renderDoctor));
+      } else {
+        btn.disabled = true;
+      }
       wrap.appendChild(btn);
     }
   }


### PR DESCRIPTION
## Summary
- Make "Doctor" activity accessible from Activities window
- Add doctor visit UI with routine check-up and illness treatment affecting health and money

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3bf6ae77c832aa9f82695b90ff4c2