### PR TITLE
Add help window and dock button

### DIFF
--- a/partials/dock.html
+++ b/partials/dock.html
@@ -7,6 +7,8 @@
   <button data-toggle="log">Log</button>
   <button data-toggle="jobs">Job Hunt</button>
   <button data-toggle="realestate">Real Estate</button>
+  <button data-toggle="help">Help</button>
   <button id="newLife">New Life</button>
   <button id="themeToggle" title="Toggle theme" style="margin-left:auto">🌙</button>
 </div>
+

--- a/renderers/help.js
+++ b/renderers/help.js
@@ -1,0 +1,17 @@
+export function renderHelp(container) {
+  const wrap = document.createElement('div');
+  wrap.className = 'help';
+  const lines = [
+    'Goal: live as long as you can while improving your stats.',
+    'Drag window title bars to move them. Use the dock buttons to show or hide windows.',
+    'Use the Actions window to age up and progress through life.',
+    'Jobs unlock at age 16. Visit Job Hunt to start working and earn money.'
+  ];
+  for (const text of lines) {
+    const p = document.createElement('p');
+    p.textContent = text;
+    wrap.appendChild(p);
+  }
+  container.appendChild(wrap);
+}
+

--- a/script.js
+++ b/script.js
@@ -7,6 +7,7 @@ import { renderJobs } from './renderers/jobs.js';
 import { renderCharacter } from './renderers/character.js';
 import { renderActivities } from './renderers/activities.js';
 import { renderRealEstate } from './renderers/realestate.js';
+import { renderHelp } from './renderers/help.js';
 
 async function loadPartials() {
   await Promise.all([
@@ -56,6 +57,9 @@ function openActivities() {
 function openRealEstate() {
   openWindow('realestate', 'Real Estate', renderRealEstate);
 }
+function openHelp() {
+  openWindow('help', 'Help', renderHelp);
+}
 
 function toggleStats() {
   toggleWindow('stats', 'Stats', renderStats);
@@ -78,6 +82,9 @@ function toggleActivities() {
 function toggleRealEstate() {
   toggleWindow('realestate', 'Real Estate', renderRealEstate);
 }
+function toggleHelp() {
+  toggleWindow('help', 'Help', renderHelp);
+}
 
 document.querySelectorAll('[data-toggle]').forEach(btn => {
   btn.addEventListener('click', () => {
@@ -89,6 +96,7 @@ document.querySelectorAll('[data-toggle]').forEach(btn => {
     if (id === 'character') toggleCharacter();
     if (id === 'activities') toggleActivities();
     if (id === 'realestate') toggleRealEstate();
+    if (id === 'help') toggleHelp();
   });
 });
 
@@ -107,3 +115,4 @@ openStats();
 openActions();
 openLog();
 openCharacter();
+


### PR DESCRIPTION
## Summary
- Add Help button to dock to open an instructional window
- Introduce Help renderer and open/toggle functions
- Update toggle handling to support Help window

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a927b7c0832aba1cf5be8150b777