### PR TITLE
Add localStorage persistence for game state

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -1,4 +1,4 @@
-import { game, addLog, die } from './state.js';
+import { game, addLog, die, saveGame } from './state.js';
 import { rand, clamp } from './utils.js';
 import { tickJail } from './jail.js';
 import { tickRelationships } from './activities/love.js';
@@ -46,6 +46,7 @@ function randomEvent() {
 export function ageUp() {
   if (!game.alive) {
     addLog('You are no longer alive. Start a new life.');
+    saveGame();
     return;
   }
   game.age += 1;
@@ -69,6 +70,7 @@ export function ageUp() {
   tickJail();
   tickRelationships();
   refreshOpenWindows();
+  saveGame();
 }
 
 export function study() {
@@ -82,15 +84,18 @@ export function study() {
   game.happiness = clamp(game.happiness + mood);
   addLog(`You studied hard. +${gain} Smarts${mood < 0 ? ` • ${mood} Happiness` : ''}.`);
   refreshOpenWindows();
+  saveGame();
 }
 
 export function workExtra() {
   if (!game.job) {
     addLog('You need a job first.');
+    saveGame();
     return;
   }
   if (game.inJail) {
     addLog('You cannot work extra while in jail.');
+    saveGame();
     return;
   }
   const bonus = rand(200, 1500);
@@ -99,6 +104,7 @@ export function workExtra() {
   game.health = clamp(game.health - rand(0, 2));
   addLog(`You took overtime. Earned $${bonus.toLocaleString()}. (-Small Health/Happiness)`);
   refreshOpenWindows();
+  saveGame();
 }
 
 export function hitGym() {
@@ -110,6 +116,7 @@ export function hitGym() {
     const cost = 20;
     if (game.money < cost) {
       addLog('Not enough money for the gym ($20).');
+      saveGame();
       return;
     }
     game.money -= cost;
@@ -118,16 +125,19 @@ export function hitGym() {
     addLog('You hit the gym. (+Health, +Happiness)');
   }
   refreshOpenWindows();
+  saveGame();
 }
 
 export function seeDoctor() {
   if (game.inJail) {
     addLog('No access to a doctor here.');
+    saveGame();
     return;
   }
   const cost = game.sick ? 120 : 60;
   if (game.money < cost) {
     addLog(`Doctor visit costs $${cost}. Not enough money.`);
+    saveGame();
     return;
   }
   game.money -= cost;
@@ -140,11 +150,13 @@ export function seeDoctor() {
     addLog('Routine check-up made you feel better. (+Health)');
   }
   refreshOpenWindows();
+  saveGame();
 }
 
 export function crime() {
   if (game.inJail) {
     addLog('You are already in jail.');
+    saveGame();
     return;
   }
   const crimes = [
@@ -175,5 +187,6 @@ export function crime() {
     }
   }
   refreshOpenWindows();
+  saveGame();
 }
 

--- a/activities/adoption.js
+++ b/activities/adoption.js
@@ -1,4 +1,4 @@
-import { game, addLog } from '../state.js';
+import { game, addLog, saveGame } from '../state.js';
 import { openWindow, refreshOpenWindows } from '../windowManager.js';
 import { faker } from 'https://cdn.jsdelivr.net/npm/@faker-js/faker@8.3.1/+esm';
 
@@ -29,6 +29,7 @@ export function renderAdoption(container) {
       game.children.push(child);
       addLog(`You adopted ${name}.`);
       refreshOpenWindows();
+      saveGame();
     });
     wrap.appendChild(btn);
   }

--- a/activities/casino.js
+++ b/activities/casino.js
@@ -1,4 +1,4 @@
-import { game, addLog } from '../state.js';
+import { game, addLog, saveGame } from '../state.js';
 import { rand, clamp } from '../utils.js';
 import { refreshOpenWindows, openWindow as windowOpen } from '../windowManager.js';
 
@@ -17,6 +17,7 @@ export function renderCasino(container) {
     if (game.money < bet) {
       addLog('Not enough money to gamble.');
       refreshOpenWindows();
+      saveGame();
       return;
     }
     game.money -= bet;
@@ -38,6 +39,7 @@ export function renderCasino(container) {
       result.textContent = `Result: ${reels.join(' ')} - Loss`;
     }
     refreshOpenWindows();
+    saveGame();
   });
 
   wrap.appendChild(btn);

--- a/activities/doctor.js
+++ b/activities/doctor.js
@@ -1,4 +1,4 @@
-import { game, addLog } from '../state.js';
+import { game, addLog, saveGame } from '../state.js';
 import { clamp, rand } from '../utils.js';
 import { refreshOpenWindows } from '../windowManager.js';
 
@@ -20,12 +20,14 @@ export function renderDoctor(container) {
       const cost = 60;
       if (game.money < cost) {
         addLog(`Doctor visit costs $${cost}. Not enough money.`);
+        saveGame();
         return;
       }
       game.money -= cost;
       game.health = clamp(game.health + rand(2, 6));
       addLog('Routine check-up made you feel better. (+Health)');
       refreshOpenWindows();
+      saveGame();
     })
   );
 
@@ -36,6 +38,7 @@ export function renderDoctor(container) {
         const cost = 120;
         if (game.money < cost) {
           addLog(`Doctor visit costs $${cost}. Not enough money.`);
+          saveGame();
           return;
         }
         game.money -= cost;
@@ -43,6 +46,7 @@ export function renderDoctor(container) {
         game.health = clamp(game.health + rand(6, 12));
         addLog('The doctor treated your illness. (+Health)');
         refreshOpenWindows();
+        saveGame();
       },
       !game.sick
     )

--- a/activities/lottery.js
+++ b/activities/lottery.js
@@ -1,4 +1,4 @@
-import { game, addLog } from '../state.js';
+import { game, addLog, saveGame } from '../state.js';
 import { rand, clamp } from '../utils.js';
 import { openWindow, refreshOpenWindows } from '../windowManager.js';
 
@@ -34,6 +34,7 @@ export function renderLottery(container) {
     game.happiness = clamp(game.happiness + mood);
     addLog(msg);
     refreshOpenWindows();
+    saveGame();
   });
   wrap.appendChild(btn);
   container.appendChild(wrap);

--- a/activities/love.js
+++ b/activities/love.js
@@ -1,4 +1,4 @@
-import { game, addLog } from '../state.js';
+import { game, addLog, saveGame } from '../state.js';
 import { rand, clamp } from '../utils.js';
 import { refreshOpenWindows } from '../windowManager.js';
 import { faker } from 'https://cdn.jsdelivr.net/npm/@faker-js/faker@8.3.1/+esm';
@@ -31,6 +31,7 @@ export function renderLove(container) {
         game.relationships.splice(i, 1);
         addLog(`You broke up with ${rel.name}.`);
         refreshOpenWindows();
+        saveGame();
       });
       row.appendChild(btn);
 
@@ -48,6 +49,7 @@ export function renderLove(container) {
     game.relationships.push(partner);
     addLog(`You started dating ${name}.`);
     refreshOpenWindows();
+    saveGame();
   });
   wrap.appendChild(findBtn);
 
@@ -64,5 +66,6 @@ export function tickRelationships() {
     }
   }
   refreshOpenWindows();
+  saveGame();
 }
 

--- a/activities/pets.js
+++ b/activities/pets.js
@@ -1,4 +1,4 @@
-import { game, addLog } from '../state.js';
+import { game, addLog, saveGame } from '../state.js';
 import { refreshOpenWindows, openWindow } from '../windowManager.js';
 
 export { openWindow };
@@ -29,12 +29,14 @@ export function renderPets(container) {
       if (game.money < a.cost) {
         addLog('You cannot afford that pet.');
         refreshOpenWindows();
+        saveGame();
         return;
       }
       game.money -= a.cost;
       game.pets.push({ type: a.type, age: 0, happiness: 70 });
       addLog(`You adopted a ${a.type}.`);
       refreshOpenWindows();
+      saveGame();
     });
     list.appendChild(btn);
   }
@@ -60,6 +62,7 @@ export function renderPets(container) {
         pet.happiness = Math.min(pet.happiness + 10, 100);
         addLog(`You played with your ${pet.type}.`);
         refreshOpenWindows();
+        saveGame();
       });
       actions.appendChild(play);
       const ageBtn = document.createElement('button');
@@ -70,6 +73,7 @@ export function renderPets(container) {
         pet.happiness = Math.max(pet.happiness - 5, 0);
         addLog(`Your ${pet.type} aged a year.`);
         refreshOpenWindows();
+        saveGame();
       });
       actions.appendChild(ageBtn);
       row.appendChild(actions);

--- a/activities/vacation.js
+++ b/activities/vacation.js
@@ -1,4 +1,4 @@
-import { game, addLog } from '../state.js';
+import { game, addLog, saveGame } from '../state.js';
 import { clamp, rand } from '../utils.js';
 import { refreshOpenWindows } from '../windowManager.js';
 
@@ -16,6 +16,7 @@ export function renderVacation(container) {
     if (game.money < cost) {
       addLog('Vacation costs $500. Not enough money.');
       refreshOpenWindows();
+      saveGame();
       return;
     }
     game.money -= cost;
@@ -23,6 +24,7 @@ export function renderVacation(container) {
     game.happiness = clamp(game.happiness + gain);
     addLog(`You went on a vacation. +${gain} Happiness.`);
     refreshOpenWindows();
+    saveGame();
   });
 
   container.appendChild(btn);

--- a/jail.js
+++ b/jail.js
@@ -1,4 +1,4 @@
-import { game, addLog } from './state.js';
+import { game, addLog, saveGame } from './state.js';
 
 export function tickJail() {
   if (!game.inJail) return;
@@ -9,4 +9,5 @@ export function tickJail() {
     delete game.jailYears;
     addLog('You were released from jail.');
   }
+  saveGame();
 }

--- a/jobs.js
+++ b/jobs.js
@@ -1,5 +1,5 @@
 import { rand } from './utils.js';
-import { game } from './state.js';
+import { game, saveGame } from './state.js';
 
 export function generateJobs() {
   if (game.jobListingsYear === game.year && game.jobListings.length) {
@@ -30,5 +30,6 @@ export function generateJobs() {
   }
   game.jobListings = options;
   game.jobListingsYear = game.year;
+  saveGame();
   return options;
 }

--- a/realestate.js
+++ b/realestate.js
@@ -1,4 +1,4 @@
-import { game, addLog } from './state.js';
+import { game, addLog, saveGame } from './state.js';
 import { rand, clamp } from './utils.js';
 import { faker } from 'https://cdn.jsdelivr.net/npm/@faker-js/faker@8.3.1/+esm';
 
@@ -11,6 +11,7 @@ export const propertyListings = [
 export function buyProperty(listing) {
   if (game.money < listing.value) {
     addLog(`Not enough money to buy ${listing.name}.`);
+    saveGame();
     return false;
   }
   game.money -= listing.value;
@@ -25,12 +26,14 @@ export function buyProperty(listing) {
   };
   game.properties.push(prop);
   addLog(`You bought ${listing.name} for $${listing.value.toLocaleString()}.`);
+  saveGame();
   return true;
 }
 
 export function rentProperty(prop, percent) {
   if (prop.rented) {
     addLog(`${prop.name} is already rented.`);
+    saveGame();
     return;
   }
   const pct = clamp(percent, 1, 10);
@@ -40,12 +43,14 @@ export function rentProperty(prop, percent) {
   prop.rent = rent;
   prop.tenant = tenant;
   addLog(`You rented ${prop.name} to ${tenant} for $${rent.toLocaleString()} per year.`);
+  saveGame();
 }
 
 export function repairProperty(prop, percent) {
   const cost = Math.round(prop.value * percent / 100);
   if (game.money < cost) {
     addLog(`Repairing ${prop.name} costs $${cost.toLocaleString()}. Not enough money.`);
+    saveGame();
     return;
   }
   game.money -= cost;
@@ -62,6 +67,7 @@ export function repairProperty(prop, percent) {
   } else {
     addLog(`Repair failed on ${prop.name}.`);
   }
+  saveGame();
 }
 
 export function tickRealEstate() {

--- a/renderers/jobs.js
+++ b/renderers/jobs.js
@@ -1,4 +1,4 @@
-import { game, addLog } from '../state.js';
+import { game, addLog, saveGame } from '../state.js';
 import { generateJobs } from '../jobs.js';
 import { refreshOpenWindows } from '../windowManager.js';
 
@@ -26,11 +26,13 @@ export function renderJobs(container) {
       if (!ok) {
         addLog('You were not qualified for that role. (+Study to improve Smarts)');
         refreshOpenWindows();
+        saveGame();
         return;
       }
       game.job = j;
       addLog(`You became a ${j.title}. Salary $${j.salary.toLocaleString()}/yr.`);
       refreshOpenWindows();
+      saveGame();
     });
     wrap.appendChild(e);
   }

--- a/script.js
+++ b/script.js
@@ -1,5 +1,5 @@
 import { initWindowManager, openWindow, toggleWindow } from './windowManager.js';
-import { newLife } from './state.js';
+import { newLife, loadGame } from './state.js';
 import { renderStats } from './renderers/stats.js';
 import { renderActions } from './renderers/actions.js';
 import { renderLog } from './renderers/log.js';
@@ -102,7 +102,9 @@ document.getElementById('themeToggle').addEventListener('click', () => {
   localStorage.setItem('theme', theme);
 });
 
-newLife();
+if (!loadGame()) {
+  newLife();
+}
 openStats();
 openActions();
 openLog();

--- a/state.js
+++ b/state.js
@@ -40,9 +40,22 @@ export function die(reason) {
   showEndScreen(game);
 }
 
+export function saveGame() {
+  localStorage.setItem('gameState', JSON.stringify(game));
+}
+
+export function loadGame() {
+  const data = localStorage.getItem('gameState');
+  if (!data) return false;
+  Object.assign(game, JSON.parse(data));
+  refreshOpenWindows();
+  return true;
+}
+
 export function newLife() {
   const now = new Date().getFullYear();
   hideEndScreen();
+  localStorage.removeItem('gameState');
   const gender = rand(0, 1) === 0 ? 'Male' : 'Female';
   const firstName = faker.person.firstName(gender === 'Male' ? 'male' : 'female');
   const lastName = faker.person.lastName();
@@ -74,5 +87,6 @@ export function newLife() {
   });
   addLog('You were born. A new life begins.');
   refreshOpenWindows();
+  saveGame();
 }
 


### PR DESCRIPTION
## Summary
- Save and load complete game state to localStorage
- Persist state changes after gameplay actions and load previous saves on startup
- Clear stored data when beginning a new life

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a94f6cac832aa9aad3ebd42b59ed