### PR TITLE
Prompt for confirmation before starting new life

### DIFF
--- a/script.js
+++ b/script.js
@@ -101,7 +101,10 @@ document.querySelectorAll('[data-toggle]').forEach(btn => {
 });
 
 document.getElementById('newLife').addEventListener('click', () => {
-  newLife();
+  if (confirm('Start a new life? Your current progress will be lost.')) {
+    newLife();
+    openStats();
+  }
 });
 
 document.getElementById('themeToggle').addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- Ask for confirmation before resetting the game, warning the player about lost progress.
- Refocus the Stats window after a reset to highlight the fresh state.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8aefb4b38832a9af47af1608d7eaa