### PR TITLE
Persist window state in localStorage

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,4 +1,4 @@
-import { initWindowManager, openWindow, toggleWindow } from './windowManager.js';
+import { initWindowManager, openWindow, toggleWindow, registerWindow, restoreOpenWindows } from './windowManager.js';
 import { newLife, loadGame } from './state.js';
 import { renderStats } from './renderers/stats.js';
 import { renderActions } from './renderers/actions.js';
@@ -35,6 +35,17 @@ const desktop = document.getElementById('desktop');
 const template = document.getElementById('window-template');
 
 initWindowManager(desktop, template);
+
+registerWindow('stats', 'Stats', renderStats);
+registerWindow('actions', 'Actions', renderActions);
+registerWindow('log', 'Log', renderLog);
+registerWindow('jobs', 'Jobs', renderJobs);
+registerWindow('character', 'Character', renderCharacter);
+registerWindow('activities', 'Activities', renderActivities);
+registerWindow('realestate', 'Real Estate', renderRealEstate);
+registerWindow('help', 'Help', renderHelp);
+
+restoreOpenWindows();
 
 function openStats() {
   openWindow('stats', 'Stats', renderStats);


### PR DESCRIPTION
## Summary
- Track open windows in `localStorage` and restore them on load
- Provide helpers to register windows and reopen previous sessions
- Close or open windows updates the stored list, clearing it when empty

## Testing
- `npm test` *(fails: command not found: npm)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b8aeef2c28832ab7b4cc0e543fd27a