### PR TITLE
Add close-all windows capability and UI hook

### DIFF
--- a/partials/dock.html
+++ b/partials/dock.html
@@ -9,6 +9,7 @@
   <button data-toggle="realestate">Real Estate</button>
   <button data-toggle="help">Help</button>
   <button id="newLife">New Life</button>
+  <button id="closeAll">Close All</button>
   <button id="themeToggle" title="Toggle theme" style="margin-left:auto">🌙</button>
 </div>
 

--- a/script.js
+++ b/script.js
@@ -1,4 +1,4 @@
-import { initWindowManager, openWindow, toggleWindow, registerWindow, restoreOpenWindows } from './windowManager.js';
+import { initWindowManager, openWindow, toggleWindow, registerWindow, restoreOpenWindows, closeAllWindows } from './windowManager.js';
 import { newLife, loadGame } from './state.js';
 import { renderStats } from './renderers/stats.js';
 import { renderActions } from './renderers/actions.js';
@@ -100,6 +100,10 @@ document.getElementById('newLife').addEventListener('click', () => {
     newLife();
     openStats();
   }
+});
+
+document.getElementById('closeAll').addEventListener('click', () => {
+  closeAllWindows();
 });
 
 document.getElementById('themeToggle').addEventListener('click', () => {

--- a/windowManager.js
+++ b/windowManager.js
@@ -245,3 +245,11 @@ export function refreshOpenWindows() {
   }
 }
 
+export function closeAllWindows() {
+  document.querySelectorAll('.window:not(.hidden)').forEach(win => {
+    win.classList.add('hidden');
+  });
+  setActive();
+  persistOpenWindows();
+}
+


### PR DESCRIPTION
## Summary
- Implement `closeAllWindows` in window manager to hide all visible windows and clear active state
- Add "Close All" button in dock partial and wire it to the new function

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b06b4d54832a8ba48f7b0b55ad5e