### PR TITLE
Add service worker for asset caching

### DIFF
--- a/script.js
+++ b/script.js
@@ -9,6 +9,12 @@ import { renderActivities } from './renderers/activities.js';
 import { renderRealEstate } from './renderers/realestate.js';
 import { renderHelp } from './renderers/help.js';
 
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/service-worker.js');
+  });
+}
+
 async function loadPartials() {
   const loadDock = async () => {
     try {

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,36 @@
+const CACHE_VERSION = 'v1';
+const CACHE_NAME = `tiny-life-cache-${CACHE_VERSION}`;
+const CORE_ASSETS = [
+  '/index.html',
+  '/base.css',
+  '/components.css',
+  '/variables.css',
+  '/script.js',
+  '/actions.js',
+  '/state.js',
+  '/windowManager.js',
+  '/utils.js',
+  '/storyNet.js',
+  '/partials/dock.html',
+  '/partials/window-template.html'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(CORE_ASSETS))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys => Promise.all(
+      keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))
+    ))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- cache core assets with new versioned service worker
- register service worker on page load

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b0924b14832a9d050faca291966d