### PR TITLE
Save game state on tab close

### DIFF
--- a/state.js
+++ b/state.js
@@ -92,3 +92,5 @@ export function newLife() {
   saveGame();
 }
 
+window.addEventListener('beforeunload', saveGame);
+


### PR DESCRIPTION
## Summary
- export and persist saveGame function
- attach beforeunload listener to save game state when tab closes

## Testing
- `npm test` *(fails: Could not read package.json: ENOENT: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b09e25f8832aae8c7dc22ec25ab0