### PR TITLE
Dispatch window events and highlight active dock buttons

### DIFF
--- a/components.css
+++ b/components.css
@@ -11,6 +11,7 @@
   transition: transform .05s ease, background .2s ease, border-color .2s ease;
 }
 .dock button:hover{ transform: translateY(-1px); border-color: rgba(255,255,255,.35); }
+.dock button.active{ border-color: rgba(255,255,255,.55); background: rgba(255,255,255,.15); }
 
 .window{
   position:absolute; min-width: 280px; max-width: 520px; width: 380px; border-radius: var(--radius);

--- a/script.js
+++ b/script.js
@@ -53,6 +53,20 @@ const template = document.getElementById('window-template');
 
 initWindowManager(desktop, template);
 
+window.addEventListener('window-open', e => {
+  const { id } = e.detail;
+  document.querySelectorAll(`[data-toggle="${id}"]`).forEach(btn => {
+    btn.classList.add('active');
+  });
+});
+
+window.addEventListener('window-close', e => {
+  const { id } = e.detail;
+  document.querySelectorAll(`[data-toggle="${id}"]`).forEach(btn => {
+    btn.classList.remove('active');
+  });
+});
+
 registerWindow('stats', 'Stats', renderStats);
 registerWindow('actions', 'Actions', renderActions);
 registerWindow('log', 'Log', renderLog);

--- a/windowManager.js
+++ b/windowManager.js
@@ -201,6 +201,7 @@ export function openWindow(id, title, renderFn) {
   win.classList.remove('hidden');
   bringToFront(win);
   persistOpenWindows();
+  window.dispatchEvent(new CustomEvent('window-open', { detail: { id, win } }));
 }
 
 export function toggleWindow(id, title, renderFn) {
@@ -221,6 +222,7 @@ export function closeWindow(id) {
     bringToFront(others[others.length - 1]);
   }
   persistOpenWindows();
+  window.dispatchEvent(new CustomEvent('window-close', { detail: { id, win } }));
 }
 
 export function restoreOpenWindows() {


### PR DESCRIPTION
## Summary
- Emit `window-open` and `window-close` events from the window manager.
- Track these events in the main script to toggle an `active` class on `[data-toggle]` buttons.
- Style dock buttons with an `active` state for visual feedback.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b05b7754832aad0adb6d55808ffe