### PR TITLE
Replace new life popup with dedicated tab

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,9 @@ This repository contains static web assets (HTML, CSS, JavaScript).
 - End all files with a newline.
 - For JavaScript, use semicolons and prefer `const`/`let` over `var`.
 
+## UI guidelines
+- Avoid browser popups. Use in-game tabs or windows for confirmations.
+
 ## Testing
 - Run `npm test` before committing changes. If the command fails due to missing tests, capture the output for the pull request.
 

--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@ Tiny Life is a browser-based life simulation inspired by BitLife. The game uses 
 
 ## Getting Started
 Open `index.html` in any modern web browser to play. No build tools or server are required.
+
+## Development Notes
+- Avoid browser popups. Use in-game tabs or windows for confirmations.
+

--- a/partials/dock.html
+++ b/partials/dock.html
@@ -8,7 +8,7 @@
   <button data-toggle="jobs">Job Hunt</button>
   <button data-toggle="realestate">Real Estate</button>
   <button data-toggle="help">Help</button>
-  <button id="newLife">New Life</button>
+  <button data-toggle="newLife">New Life</button>
   <button id="themeToggle" title="Toggle theme" style="margin-left:auto">🌙</button>
 </div>
 

--- a/renderers/newlife.js
+++ b/renderers/newlife.js
@@ -1,0 +1,31 @@
+import { newLife } from '../state.js';
+import { openWindow, closeWindow } from '../windowManager.js';
+import { renderStats } from './stats.js';
+
+export function renderNewLife(container) {
+  const wrap = document.createElement('div');
+  wrap.className = 'new-life';
+
+  const msg = document.createElement('p');
+  msg.textContent = 'Start a new life? Your current progress will be lost.';
+  wrap.appendChild(msg);
+
+  const start = document.createElement('button');
+  start.textContent = 'Start New Life';
+  start.addEventListener('click', () => {
+    newLife();
+    openWindow('stats', 'Stats', renderStats);
+    closeWindow('newLife');
+  });
+  wrap.appendChild(start);
+
+  const cancel = document.createElement('button');
+  cancel.textContent = 'Cancel';
+  cancel.addEventListener('click', () => {
+    closeWindow('newLife');
+  });
+  wrap.appendChild(cancel);
+
+  container.appendChild(wrap);
+}
+

--- a/script.js
+++ b/script.js
@@ -8,6 +8,7 @@ import { renderCharacter } from './renderers/character.js';
 import { renderActivities } from './renderers/activities.js';
 import { renderRealEstate } from './renderers/realestate.js';
 import { renderHelp } from './renderers/help.js';
+import { renderNewLife } from './renderers/newlife.js';
 
 async function loadPartials() {
   const loadDock = async () => {
@@ -61,6 +62,7 @@ registerWindow('character', 'Character', renderCharacter);
 registerWindow('activities', 'Activities', renderActivities);
 registerWindow('realestate', 'Real Estate', renderRealEstate);
 registerWindow('help', 'Help', renderHelp);
+registerWindow('newLife', 'New Life', renderNewLife);
 
 restoreOpenWindows();
 
@@ -72,7 +74,8 @@ const windows = {
   character: { title: 'Character', renderer: renderCharacter },
   activities: { title: 'Activities', renderer: renderActivities },
   realestate: { title: 'Real Estate', renderer: renderRealEstate },
-  help: { title: 'Help', renderer: renderHelp }
+  help: { title: 'Help', renderer: renderHelp },
+  newLife: { title: 'New Life', renderer: renderNewLife }
 };
 
 function openWindowById(id) {
@@ -93,13 +96,6 @@ Object.keys(windows).forEach(id => {
   document.querySelectorAll(`[data-toggle="${id}"]`).forEach(btn => {
     btn.addEventListener('click', () => toggleWindowById(id));
   });
-});
-
-document.getElementById('newLife').addEventListener('click', () => {
-  if (confirm('Start a new life? Your current progress will be lost.')) {
-    newLife();
-    openStats();
-  }
 });
 
 document.getElementById('themeToggle').addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- Replace browser confirm for restarting with a New Life tab
- Document avoiding browser popups in AGENTS and README

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b0f64500832aab2494dbf903c8d8