### PR TITLE
Add shopping activity

### DIFF
--- a/activities/shopping.js
+++ b/activities/shopping.js
@@ -1,5 +1,50 @@
+import { game, addLog, saveGame } from '../state.js';
+import { clamp, rand } from '../utils.js';
+import { refreshOpenWindows } from '../windowManager.js';
+
+const GOODS = [
+  { name: 'Gourmet Chocolate', cost: 30, happiness: 4 },
+  { name: 'Designer Shoes', cost: 120, happiness: 8 },
+  { name: 'Scratch-off Ticket', cost: 5, money: () => rand(0, 50) }
+];
+
 export function renderShopping(container) {
   const wrap = document.createElement('div');
-  wrap.textContent = 'Shopping coming soon';
+
+  const head = document.createElement('div');
+  head.className = 'muted';
+  head.textContent = 'Retail therapy for better vibes.';
+  wrap.appendChild(head);
+
+  for (const item of GOODS) {
+    const btn = document.createElement('button');
+    btn.className = 'btn';
+    btn.textContent = `${item.name} ($${item.cost})`;
+    btn.disabled = game.money < item.cost;
+    btn.addEventListener('click', () => {
+      if (game.money < item.cost) {
+        addLog(`You cannot afford ${item.name}.`);
+        refreshOpenWindows();
+        saveGame();
+        return;
+      }
+      game.money -= item.cost;
+      let log = `You bought ${item.name}.`;
+      if (item.happiness) {
+        game.happiness = clamp(game.happiness + item.happiness);
+        log += ` +${item.happiness} Happiness.`;
+      }
+      if (item.money) {
+        const gain = typeof item.money === 'function' ? item.money() : item.money;
+        game.money += gain;
+        log += ` +$${gain}.`;
+      }
+      addLog(log);
+      refreshOpenWindows();
+      saveGame();
+    });
+    wrap.appendChild(btn);
+  }
+
   container.appendChild(wrap);
 }

--- a/renderers/activities.js
+++ b/renderers/activities.js
@@ -6,6 +6,7 @@ import { renderPets } from '../activities/pets.js';
 import { renderAdoption } from '../activities/adoption.js';
 import { renderCasino } from '../activities/casino.js';
 import { renderDoctor } from '../activities/doctor.js';
+import { renderShopping } from '../activities/shopping.js';
 
 const ACTIVITIES_CATEGORIES = {
   'Leisure & Lifestyle': [
@@ -63,7 +64,8 @@ const ACTIVITY_RENDERERS = {
   Adoption: () => openWindow('adoption', 'Adoption', renderAdoption),
   Lottery: () => openWindow('lottery', 'Lottery', renderLottery),
   Vacation: () => openWindow('vacation', 'Vacation', renderVacation),
-  Pets: () => openWindow('pets', 'Pets', renderPets)
+  Pets: () => openWindow('pets', 'Pets', renderPets),
+  Shopping: () => openWindow('shopping', 'Shopping', renderShopping)
 };
 
 export function renderActivities(container) {


### PR DESCRIPTION
## Summary
- Expand shopping activity with purchasable goods affecting happiness or money
- Wire shopping activity into activities renderer

## Testing
- `npm test` *(fails: ENOENT missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b47b9584832ab4773768ed60a77b