### PR TITLE
Add fertility treatment activity

### DIFF
--- a/activities/fertility.js
+++ b/activities/fertility.js
@@ -1,5 +1,41 @@
+import { game, addLog, saveGame } from '../state.js';
+import { refreshOpenWindows } from '../windowManager.js';
+import { faker } from 'https://cdn.jsdelivr.net/npm/@faker-js/faker@8.3.1/+esm';
+
+const TREATMENTS = [
+  { label: 'Intrauterine Insemination', cost: 3000, success: 0.25 },
+  { label: 'In Vitro Fertilization', cost: 15000, success: 0.4 },
+  { label: 'Surrogacy', cost: 60000, success: 0.9 }
+];
+
 export function renderFertility(container) {
   const wrap = document.createElement('div');
-  wrap.textContent = 'Fertility coming soon';
+
+  for (const t of TREATMENTS) {
+    const btn = document.createElement('button');
+    btn.className = 'btn block';
+    btn.textContent = `${t.label} - $${t.cost.toLocaleString()} (${Math.round(t.success * 100)}% success)`;
+    if (game.money < t.cost) {
+      btn.disabled = true;
+    }
+    btn.addEventListener('click', () => {
+      if (game.money < t.cost) return;
+      game.money -= t.cost;
+      if (Math.random() < t.success) {
+        const name = faker.person.firstName();
+        const child = { name, age: 0, happiness: 90 };
+        if (!game.children) game.children = [];
+        game.children.push(child);
+        addLog(`Fertility treatment succeeded! You welcomed ${name}.`);
+      } else {
+        addLog('Fertility treatment failed.');
+      }
+      refreshOpenWindows();
+      saveGame();
+    });
+    wrap.appendChild(btn);
+  }
+
   container.appendChild(wrap);
 }
+

--- a/renderers/activities.js
+++ b/renderers/activities.js
@@ -4,6 +4,7 @@ import { renderLottery } from '../activities/lottery.js';
 import { renderLove } from '../activities/love.js';
 import { renderPets } from '../activities/pets.js';
 import { renderAdoption } from '../activities/adoption.js';
+import { renderFertility } from '../activities/fertility.js';
 import { renderCasino } from '../activities/casino.js';
 import { renderDoctor } from '../activities/doctor.js';
 
@@ -61,6 +62,7 @@ const ACTIVITY_RENDERERS = {
   Doctor: () => openWindow('doctor', 'Doctor', renderDoctor),
   Casino: () => openWindow('casino', 'Casino', renderCasino),
   Adoption: () => openWindow('adoption', 'Adoption', renderAdoption),
+  Fertility: () => openWindow('fertility', 'Fertility', renderFertility),
   Lottery: () => openWindow('lottery', 'Lottery', renderLottery),
   Vacation: () => openWindow('vacation', 'Vacation', renderVacation),
   Pets: () => openWindow('pets', 'Pets', renderPets)


### PR DESCRIPTION
## Summary
- expand fertility activities with treatment options, costs, and success chances
- wire fertility activity into activities renderer

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b482c60c832a8f1f12f4f7f311ff