### PR TITLE
feat: add basic gambling activity

### DIFF
--- a/activities/gamble.js
+++ b/activities/gamble.js
@@ -1,5 +1,51 @@
+import { game, addLog, saveGame } from '../state.js';
+import { rand } from '../utils.js';
+import { refreshOpenWindows, openWindow } from '../windowManager.js';
+
+export { openWindow };
+
 export function renderGamble(container) {
   const wrap = document.createElement('div');
-  wrap.textContent = 'Gamble coming soon';
+
+  const input = document.createElement('input');
+  input.type = 'number';
+  input.min = '1';
+  input.value = '10';
+  input.style.width = '80px';
+
+  const btn = document.createElement('button');
+  btn.className = 'btn';
+  btn.textContent = 'Bet';
+
+  const result = document.createElement('div');
+  result.className = 'muted';
+
+  btn.addEventListener('click', () => {
+    const bet = Math.floor(Number(input.value));
+    if (bet <= 0) return;
+    if (game.money < bet) {
+      addLog('Not enough money to bet.');
+      refreshOpenWindows();
+      saveGame();
+      return;
+    }
+    game.money -= bet;
+    if (rand(0, 1) === 1) {
+      const payout = bet * 2;
+      game.money += payout;
+      addLog(`You won $${payout}.`);
+      result.textContent = `Result: Won $${payout}`;
+    } else {
+      addLog(`You lost $${bet}.`);
+      result.textContent = 'Result: Loss';
+    }
+    refreshOpenWindows();
+    saveGame();
+  });
+
+  wrap.appendChild(input);
+  wrap.appendChild(btn);
+  wrap.appendChild(result);
   container.appendChild(wrap);
 }
+

--- a/renderers/activities.js
+++ b/renderers/activities.js
@@ -5,6 +5,7 @@ import { renderLove } from '../activities/love.js';
 import { renderPets } from '../activities/pets.js';
 import { renderAdoption } from '../activities/adoption.js';
 import { renderCasino } from '../activities/casino.js';
+import { renderGamble } from '../activities/gamble.js';
 import { renderDoctor } from '../activities/doctor.js';
 
 const ACTIVITIES_CATEGORIES = {
@@ -60,6 +61,7 @@ const ACTIVITY_RENDERERS = {
   Love: () => openWindow('love', 'Love', renderLove),
   Doctor: () => openWindow('doctor', 'Doctor', renderDoctor),
   Casino: () => openWindow('casino', 'Casino', renderCasino),
+  Gamble: () => openWindow('gamble', 'Gamble', renderGamble),
   Adoption: () => openWindow('adoption', 'Adoption', renderAdoption),
   Lottery: () => openWindow('lottery', 'Lottery', renderLottery),
   Vacation: () => openWindow('vacation', 'Vacation', renderVacation),


### PR DESCRIPTION
## Summary
- add gamble activity with simple win/loss betting that updates money and logs
- wire up gamble renderer so the activity is accessible from the UI

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b484f054832ab7d59dbfcab63599