### PR TITLE
Add secret agent missions and renderer integration

### DIFF
--- a/activities/secretAgent.js
+++ b/activities/secretAgent.js
@@ -1,5 +1,77 @@
+import { game, addLog, saveGame } from '../state.js';
+import { refreshOpenWindows } from '../windowManager.js';
+import { rand, clamp } from '../utils.js';
+
+const MISSIONS = [
+  {
+    label: 'Gather Intel',
+    success() {
+      const cash = rand(500, 1500);
+      game.money += cash;
+      game.smarts = clamp(game.smarts + rand(1, 3));
+      addLog(`Intel mission succeeded. +$${cash} and Smarts.`);
+    },
+    fail() {
+      const dmg = rand(5, 12);
+      game.health = clamp(game.health - dmg);
+      addLog(`Intel mission failed. -${dmg} Health.`);
+    }
+  },
+  {
+    label: 'Sabotage',
+    success() {
+      const cash = rand(2000, 4000);
+      game.money += cash;
+      game.happiness = clamp(game.happiness + rand(1, 4));
+      addLog(`Sabotage successful. +$${cash} and Happiness.`);
+    },
+    fail() {
+      const dmg = rand(10, 20);
+      game.health = clamp(game.health - dmg);
+      addLog(`You were injured during sabotage. -${dmg} Health.`);
+    }
+  },
+  {
+    label: 'Assassination',
+    success() {
+      const cash = rand(5000, 10000);
+      game.money += cash;
+      game.happiness = clamp(game.happiness + rand(2, 6));
+      addLog(`Assassination succeeded. +$${cash} and Happiness.`);
+    },
+    fail() {
+      const dmg = rand(15, 30);
+      game.health = clamp(game.health - dmg);
+      addLog(`Assassination attempt failed. -${dmg} Health.`);
+    }
+  }
+];
+
 export function renderSecretAgent(container) {
   const wrap = document.createElement('div');
-  wrap.textContent = 'Secret Agent coming soon';
+
+  const head = document.createElement('div');
+  head.className = 'muted';
+  head.textContent = 'Choose a mission. Success yields rewards; failure can be painful.';
+  wrap.appendChild(head);
+
+  for (const m of MISSIONS) {
+    const btn = document.createElement('button');
+    btn.className = 'btn block';
+    btn.textContent = m.label;
+    btn.addEventListener('click', () => {
+      const success = rand(1, 100) <= 60;
+      if (success) {
+        m.success();
+      } else {
+        m.fail();
+      }
+      refreshOpenWindows();
+      saveGame();
+    });
+    wrap.appendChild(btn);
+  }
+
   container.appendChild(wrap);
 }
+

--- a/renderers/activities.js
+++ b/renderers/activities.js
@@ -6,6 +6,7 @@ import { renderPets } from '../activities/pets.js';
 import { renderAdoption } from '../activities/adoption.js';
 import { renderCasino } from '../activities/casino.js';
 import { renderDoctor } from '../activities/doctor.js';
+import { renderSecretAgent } from '../activities/secretAgent.js';
 
 const ACTIVITIES_CATEGORIES = {
   'Leisure & Lifestyle': [
@@ -63,7 +64,8 @@ const ACTIVITY_RENDERERS = {
   Adoption: () => openWindow('adoption', 'Adoption', renderAdoption),
   Lottery: () => openWindow('lottery', 'Lottery', renderLottery),
   Vacation: () => openWindow('vacation', 'Vacation', renderVacation),
-  Pets: () => openWindow('pets', 'Pets', renderPets)
+  Pets: () => openWindow('pets', 'Pets', renderPets),
+  'Secret Agent': () => openWindow('secretAgent', 'Secret Agent', renderSecretAgent)
 };
 
 export function renderActivities(container) {


### PR DESCRIPTION
## Summary
- Introduce covert mission options in Secret Agent activity with randomized outcomes that adjust player stats and logs
- Wire Secret Agent activity into activity renderer so it can be launched from the UI

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b48aab6c832aad1c3d4da461a3f3