### PR TITLE
Improve dock accessibility and theme toggle state

### DIFF
--- a/partials/dock.html
+++ b/partials/dock.html
@@ -1,15 +1,15 @@
 <div class="dock">
   <span class="title">Tiny Life</span>
-  <button data-toggle="character">Character</button>
-  <button data-toggle="stats">Stats</button>
-  <button data-toggle="actions">Actions</button>
-  <button data-toggle="activities">Activities</button>
-  <button data-toggle="log">Log</button>
-  <button data-toggle="jobs">Job Hunt</button>
-  <button data-toggle="realestate">Real Estate</button>
-  <button data-toggle="help">Help</button>
-  <button data-toggle="newLife">New Life</button>
-  <button id="closeAll">Close All</button>
-  <button id="themeToggle" title="Toggle theme" style="margin-left:auto">🌙</button>
+  <button data-toggle="character" role="button" aria-label="Open Character window">Character</button>
+  <button data-toggle="stats" role="button" aria-label="Open Stats window">Stats</button>
+  <button data-toggle="actions" role="button" aria-label="Open Actions window">Actions</button>
+  <button data-toggle="activities" role="button" aria-label="Open Activities window">Activities</button>
+  <button data-toggle="log" role="button" aria-label="Open Log window">Log</button>
+  <button data-toggle="jobs" role="button" aria-label="Open Job Hunt window">Job Hunt</button>
+  <button data-toggle="realestate" role="button" aria-label="Open Real Estate window">Real Estate</button>
+  <button data-toggle="help" role="button" aria-label="Open Help window">Help</button>
+  <button data-toggle="newLife" role="button" aria-label="Start a new life">New Life</button>
+  <button id="closeAll" role="button" aria-label="Close all windows">Close All</button>
+  <button id="themeToggle" title="Toggle theme" style="margin-left:auto" role="button" aria-label="Toggle theme" aria-pressed="false">🌙</button>
 </div>
 

--- a/script.js
+++ b/script.js
@@ -56,6 +56,7 @@ function setTheme(theme) {
   const isDark = theme === 'dark';
   document.body.classList.toggle('dark', isDark);
   themeToggle.textContent = isDark ? '☀️' : '🌙';
+  themeToggle.setAttribute('aria-pressed', String(isDark));
   localStorage.setItem('theme', theme);
 }
 


### PR DESCRIPTION
## Summary
- add explicit role and aria-label attributes for each dock button
- toggle aria-pressed on theme button to reflect current theme

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8bdeb89b8832aba10eb207804eb1b