### PR TITLE
Improve window focus management

### DIFF
--- a/windowManager.js
+++ b/windowManager.js
@@ -264,6 +264,10 @@ export function openWindow(id, title, renderFn) {
   renderFn(c, win);
   win.classList.remove('hidden');
   bringToFront(win);
+  const focusable = win.querySelector('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+  if (focusable) {
+    focusable.focus();
+  }
   persistOpenWindows();
   window.dispatchEvent(new CustomEvent('window-open', { detail: { id, win } }));
 }
@@ -287,6 +291,13 @@ export function closeWindow(id) {
   }
   persistOpenWindows();
   window.dispatchEvent(new CustomEvent('window-close', { detail: { id, win } }));
+  const btn = document.querySelector(`[data-toggle="${id}"]`);
+  if (btn) {
+    btn.focus();
+  } else {
+    const first = document.querySelector('.dock button');
+    first?.focus();
+  }
 }
 
 export function restoreOpenWindows() {


### PR DESCRIPTION
## Summary
- Focus the first focusable element when a window is opened
- Return keyboard focus to the corresponding dock button when a window closes

## Testing
- `npm test` *(fails: Could not read package.json: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68b8bde4de24832a85296143887215f2