### PR TITLE
Guard save/load with localStorage availability check

### DIFF
--- a/state.js
+++ b/state.js
@@ -4,6 +4,17 @@ import { showEndScreen, hideEndScreen } from './endscreen.js';
 import { faker } from 'https://cdn.jsdelivr.net/npm/@faker-js/faker@8.3.1/+esm';
 import { initBrokers } from './realestate.js';
 
+export function storageAvailable() {
+  try {
+    const testKey = '__storage_test__';
+    localStorage.setItem(testKey, '1');
+    localStorage.removeItem(testKey);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
 export const game = {
   year: new Date().getFullYear(),
   age: 0,
@@ -45,10 +56,18 @@ export function die(reason) {
 }
 
 export function saveGame() {
+  if (!storageAvailable()) {
+    console.warn('Local storage is unavailable; cannot save game.');
+    return;
+  }
   localStorage.setItem('gameState', JSON.stringify(game));
 }
 
 export function loadGame() {
+  if (!storageAvailable()) {
+    console.warn('Local storage is unavailable; cannot load game.');
+    return false;
+  }
   const data = localStorage.getItem('gameState');
   if (!data) return false;
   Object.assign(game, JSON.parse(data));


### PR DESCRIPTION
## Summary
- add a `storageAvailable` helper that verifies localStorage read/write in a try/catch
- use the helper to guard `saveGame` and `loadGame`, warning when storage is unavailable

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8bde0677c832ab9c7cf1bdb9992aa