### PR TITLE
Enable keyboard navigation in dock

### DIFF
--- a/script.js
+++ b/script.js
@@ -50,7 +50,30 @@ async function loadPartials() {
 
 await loadPartials();
 
+const dock = document.querySelector('.dock');
 const themeToggle = document.getElementById('themeToggle');
+
+if (dock) {
+  const buttons = Array.from(dock.querySelectorAll('button'));
+  dock.addEventListener('keydown', e => {
+    const { key } = e;
+    const currentIndex = buttons.indexOf(document.activeElement);
+    if (key === 'ArrowRight' || key === 'ArrowDown') {
+      e.preventDefault();
+      const nextIndex = currentIndex === -1 ? 0 : (currentIndex + 1) % buttons.length;
+      buttons[nextIndex].focus();
+    } else if (key === 'ArrowLeft' || key === 'ArrowUp') {
+      e.preventDefault();
+      const prevIndex = currentIndex === -1 ? 0 : (currentIndex - 1 + buttons.length) % buttons.length;
+      buttons[prevIndex].focus();
+    } else if (key === 'Enter' || key === ' ') {
+      e.preventDefault();
+      if (currentIndex !== -1) {
+        buttons[currentIndex].click();
+      }
+    }
+  });
+}
 
 function setTheme(theme) {
   const isDark = theme === 'dark';


### PR DESCRIPTION
## Summary
- Allow arrow keys to move focus between dock buttons
- Trigger button activation with Enter or Space

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8be282618832aa25182863689b39e