### PR TITLE
Handle faker CDN failures with internal fallback

### DIFF
--- a/nameGenerator.js
+++ b/nameGenerator.js
@@ -1,0 +1,32 @@
+import { rand } from './utils.js';
+
+const maleFirst = ['John', 'Liam', 'Noah'];
+const femaleFirst = ['Emma', 'Olivia', 'Ava'];
+const lastNames = ['Smith', 'Johnson', 'Brown'];
+const cities = ['Springfield', 'Riverside', 'Greenville'];
+const countries = ['USA', 'Canada', 'UK'];
+
+export const faker = {
+  person: {
+    firstName(gender) {
+      const pool =
+        gender === 'male'
+          ? maleFirst
+          : gender === 'female'
+            ? femaleFirst
+            : [...maleFirst, ...femaleFirst];
+      return pool[rand(0, pool.length - 1)];
+    },
+    lastName() {
+      return lastNames[rand(0, lastNames.length - 1)];
+    }
+  },
+  location: {
+    city() {
+      return cities[rand(0, cities.length - 1)];
+    },
+    country() {
+      return countries[rand(0, countries.length - 1)];
+    }
+  }
+};

--- a/realestate.js
+++ b/realestate.js
@@ -1,6 +1,17 @@
 import { game, addLog, saveGame } from './state.js';
 import { rand, clamp } from './utils.js';
-import { faker } from 'https://cdn.jsdelivr.net/npm/@faker-js/faker@8.3.1/+esm';
+import { faker as fallbackFaker } from './nameGenerator.js';
+
+let faker = fallbackFaker;
+
+(async () => {
+  try {
+    const mod = await import('https://cdn.jsdelivr.net/npm/@faker-js/faker@8.3.1/+esm');
+    faker = mod.faker;
+  } catch (err) {
+    console.warn('Faker CDN import failed, using internal generator', err);
+  }
+})();
 
 // house categories with associated price ranges (ranges may overlap)
 const houseCategories = [

--- a/state.js
+++ b/state.js
@@ -1,8 +1,19 @@
 import { refreshOpenWindows } from './windowManager.js';
 import { rand } from './utils.js';
 import { showEndScreen, hideEndScreen } from './endscreen.js';
-import { faker } from 'https://cdn.jsdelivr.net/npm/@faker-js/faker@8.3.1/+esm';
+import { faker as fallbackFaker } from './nameGenerator.js';
 import { initBrokers } from './realestate.js';
+
+let faker = fallbackFaker;
+
+(async () => {
+  try {
+    const mod = await import('https://cdn.jsdelivr.net/npm/@faker-js/faker@8.3.1/+esm');
+    faker = mod.faker;
+  } catch (err) {
+    console.warn('Faker CDN import failed, using internal generator', err);
+  }
+})();
 
 export const game = {
   year: new Date().getFullYear(),


### PR DESCRIPTION
## Summary
- Wrap faker CDN imports in `state.js` and `realestate.js` with `try/catch`
- Add minimal internal name generator module as fallback when CDN is unavailable

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8be1958e0832a8e4ff817b35c2b60