### PR TITLE
feat: centralize refresh and save logic

### DIFF
--- a/activities/accessories.js
+++ b/activities/accessories.js
@@ -1,6 +1,5 @@
-import { game, addLog, saveGame } from '../state.js';
+import { game, addLog, applyAndSave } from '../state.js';
 import { clamp } from '../utils.js';
-import { refreshOpenWindows } from '../windowManager.js';
 
 const ACCESSORIES = [
   { name: 'Sunglasses', cost: 50, looks: 2 },
@@ -25,17 +24,17 @@ export function renderAccessories(container) {
     btn.disabled = game.money < item.cost;
     btn.addEventListener('click', () => {
       if (game.money < item.cost) {
-        addLog('You cannot afford that item.');
-        refreshOpenWindows();
-        saveGame();
+        applyAndSave(() => {
+          addLog('You cannot afford that item.');
+        });
         return;
       }
-      game.money -= item.cost;
-      game.looks = clamp(game.looks + item.looks);
-      game.accessories.push(item.name);
-      addLog(`You bought ${item.name}. (+Looks)`);
-      refreshOpenWindows();
-      saveGame();
+      applyAndSave(() => {
+        game.money -= item.cost;
+        game.looks = clamp(game.looks + item.looks);
+        game.accessories.push(item.name);
+        addLog(`You bought ${item.name}. (+Looks)`);
+      });
     });
     list.appendChild(btn);
   }

--- a/activities/adoption.js
+++ b/activities/adoption.js
@@ -1,5 +1,5 @@
-import { game, addLog, saveGame } from '../state.js';
-import { openWindow, refreshOpenWindows } from '../windowManager.js';
+import { game, addLog, applyAndSave } from '../state.js';
+import { openWindow } from '../windowManager.js';
 import { faker } from 'https://cdn.jsdelivr.net/npm/@faker-js/faker@8.3.1/+esm';
 
 export { openWindow };
@@ -22,14 +22,14 @@ export function renderAdoption(container) {
     }
     btn.addEventListener('click', () => {
       if (game.money < opt.cost) return;
-      game.money -= opt.cost;
-      const name = faker.person.firstName();
-      const child = { name, age: opt.age, happiness: opt.happiness };
-      if (!game.children) game.children = [];
-      game.children.push(child);
-      addLog(`You adopted ${name}.`);
-      refreshOpenWindows();
-      saveGame();
+      applyAndSave(() => {
+        game.money -= opt.cost;
+        const name = faker.person.firstName();
+        const child = { name, age: opt.age, happiness: opt.happiness };
+        if (!game.children) game.children = [];
+        game.children.push(child);
+        addLog(`You adopted ${name}.`);
+      });
     });
     wrap.appendChild(btn);
   }

--- a/activities/blackMarket.js
+++ b/activities/blackMarket.js
@@ -1,6 +1,5 @@
-import { game, addLog, saveGame } from '../state.js';
+import { game, addLog, applyAndSave } from '../state.js';
 import { rand, clamp } from '../utils.js';
-import { refreshOpenWindows } from '../windowManager.js';
 
 export function renderBlackMarket(container) {
   const wrap = document.createElement('div');
@@ -20,33 +19,33 @@ export function renderBlackMarket(container) {
   btn.addEventListener('click', () => {
     const cost = 100;
     if (game.money < cost) {
-      addLog('Contraband costs $100. Not enough money.');
-      refreshOpenWindows();
-      saveGame();
+      applyAndSave(() => {
+        addLog('Contraband costs $100. Not enough money.');
+      });
       return;
     }
 
-    game.money -= cost;
-    if (rand(1, 100) <= 30) {
-      if (rand(1, 100) <= 50) {
-        const fine = 200;
-        game.money = Math.max(0, game.money - fine);
-        addLog(`You were caught with contraband and fined $${fine}.`);
-        result.textContent = `Penalty: Fined $${fine}`;
+    applyAndSave(() => {
+      game.money -= cost;
+      if (rand(1, 100) <= 30) {
+        if (rand(1, 100) <= 50) {
+          const fine = 200;
+          game.money = Math.max(0, game.money - fine);
+          addLog(`You were caught with contraband and fined $${fine}.`);
+          result.textContent = `Penalty: Fined $${fine}`;
+        } else {
+          game.inJail = true;
+          game.jailYears = rand(1, 3);
+          addLog(`You were jailed for contraband for ${game.jailYears} year(s).`);
+          result.textContent = `Penalty: Jailed for ${game.jailYears} year(s)`;
+        }
       } else {
-        game.inJail = true;
-        game.jailYears = rand(1, 3);
-        addLog(`You were jailed for contraband for ${game.jailYears} year(s).`);
-        result.textContent = `Penalty: Jailed for ${game.jailYears} year(s)`;
+        const gain = rand(3, 6);
+        game.happiness = clamp(game.happiness + gain);
+        addLog(`Contraband acquired. +${gain} Happiness.`);
+        result.textContent = `Success: +${gain} Happiness`;
       }
-    } else {
-      const gain = rand(3, 6);
-      game.happiness = clamp(game.happiness + gain);
-      addLog(`Contraband acquired. +${gain} Happiness.`);
-      result.textContent = `Success: +${gain} Happiness`;
-    }
-    refreshOpenWindows();
-    saveGame();
+    });
   });
 
   wrap.appendChild(btn);

--- a/activities/casino.js
+++ b/activities/casino.js
@@ -1,6 +1,6 @@
-import { game, addLog, saveGame } from '../state.js';
+import { game, addLog, applyAndSave } from '../state.js';
 import { rand, clamp } from '../utils.js';
-import { refreshOpenWindows, openWindow as windowOpen } from '../windowManager.js';
+import { openWindow as windowOpen } from '../windowManager.js';
 
 export { windowOpen as openWindow };
 
@@ -15,31 +15,31 @@ export function renderCasino(container) {
   btn.addEventListener('click', () => {
     const bet = 10;
     if (game.money < bet) {
-      addLog('Not enough money to gamble.');
-      refreshOpenWindows();
-      saveGame();
+      applyAndSave(() => {
+        addLog('Not enough money to gamble.');
+      });
       return;
     }
-    game.money -= bet;
-    const reels = [rand(0, 2), rand(0, 2), rand(0, 2)];
-    const allSame = reels[0] === reels[1] && reels[1] === reels[2];
-    const pair = !allSame &&
-      (reels[0] === reels[1] || reels[0] === reels[2] || reels[1] === reels[2]);
-    let win = 0;
-    if (allSame) win = bet * 5;
-    else if (pair) win = bet * 2;
-    if (win > 0) {
-      game.money += win;
-      game.happiness = clamp(game.happiness + 4);
-      addLog(`Slots win! You earned $${win}.`);
-      result.textContent = `Result: ${reels.join(' ')} - Won $${win}`;
-    } else {
-      game.happiness = clamp(game.happiness - 2);
-      addLog('Slots loss. Better luck next time.');
-      result.textContent = `Result: ${reels.join(' ')} - Loss`;
-    }
-    refreshOpenWindows();
-    saveGame();
+    applyAndSave(() => {
+      game.money -= bet;
+      const reels = [rand(0, 2), rand(0, 2), rand(0, 2)];
+      const allSame = reels[0] === reels[1] && reels[1] === reels[2];
+      const pair = !allSame &&
+        (reels[0] === reels[1] || reels[0] === reels[2] || reels[1] === reels[2]);
+      let win = 0;
+      if (allSame) win = bet * 5;
+      else if (pair) win = bet * 2;
+      if (win > 0) {
+        game.money += win;
+        game.happiness = clamp(game.happiness + 4);
+        addLog(`Slots win! You earned $${win}.`);
+        result.textContent = `Result: ${reels.join(' ')} - Won $${win}`;
+      } else {
+        game.happiness = clamp(game.happiness - 2);
+        addLog('Slots loss. Better luck next time.');
+        result.textContent = `Result: ${reels.join(' ')} - Loss`;
+      }
+    });
   });
 
   wrap.appendChild(btn);

--- a/activities/commune.js
+++ b/activities/commune.js
@@ -1,6 +1,5 @@
-import { game, addLog, saveGame } from '../state.js';
+import { game, addLog, applyAndSave } from '../state.js';
 import { clamp, rand } from '../utils.js';
-import { refreshOpenWindows } from '../windowManager.js';
 
 const EVENTS = [
   {
@@ -48,15 +47,15 @@ export function renderCommune(container) {
     btn.textContent = ev.name;
     btn.addEventListener('click', () => {
       if (ev.cost && game.money < ev.cost) {
-        addLog(`${ev.name} costs $${ev.cost}. Not enough money.`);
-        refreshOpenWindows();
-        saveGame();
+        applyAndSave(() => {
+          addLog(`${ev.name} costs $${ev.cost}. Not enough money.`);
+        });
         return;
       }
-      if (ev.cost) game.money -= ev.cost;
-      ev.run();
-      refreshOpenWindows();
-      saveGame();
+      applyAndSave(() => {
+        if (ev.cost) game.money -= ev.cost;
+        ev.run();
+      });
     });
     container.appendChild(btn);
   }

--- a/activities/doctor.js
+++ b/activities/doctor.js
@@ -1,6 +1,5 @@
-import { game, addLog, saveGame } from '../state.js';
+import { game, addLog, applyAndSave } from '../state.js';
 import { clamp, rand } from '../utils.js';
-import { refreshOpenWindows } from '../windowManager.js';
 
 export function renderDoctor(container) {
   const wrap = document.createElement('div');
@@ -19,15 +18,16 @@ export function renderDoctor(container) {
     mk('Routine Check-Up ($60)', () => {
       const cost = 60;
       if (game.money < cost) {
-        addLog(`Doctor visit costs $${cost}. Not enough money.`);
-        saveGame();
+        applyAndSave(() => {
+          addLog(`Doctor visit costs $${cost}. Not enough money.`);
+        });
         return;
       }
-      game.money -= cost;
-      game.health = clamp(game.health + rand(2, 6));
-      addLog('Routine check-up made you feel better. (+Health)');
-      refreshOpenWindows();
-      saveGame();
+      applyAndSave(() => {
+        game.money -= cost;
+        game.health = clamp(game.health + rand(2, 6));
+        addLog('Routine check-up made you feel better. (+Health)');
+      });
     })
   );
 
@@ -37,16 +37,17 @@ export function renderDoctor(container) {
       () => {
         const cost = 120;
         if (game.money < cost) {
-          addLog(`Doctor visit costs $${cost}. Not enough money.`);
-          saveGame();
+          applyAndSave(() => {
+            addLog(`Doctor visit costs $${cost}. Not enough money.`);
+          });
           return;
         }
-        game.money -= cost;
-        game.sick = false;
-        game.health = clamp(game.health + rand(6, 12));
-        addLog('The doctor treated your illness. (+Health)');
-        refreshOpenWindows();
-        saveGame();
+        applyAndSave(() => {
+          game.money -= cost;
+          game.sick = false;
+          game.health = clamp(game.health + rand(6, 12));
+          addLog('The doctor treated your illness. (+Health)');
+        });
       },
       !game.sick
     )

--- a/activities/emigrate.js
+++ b/activities/emigrate.js
@@ -1,6 +1,5 @@
-import { game, addLog, saveGame } from '../state.js';
+import { game, addLog, applyAndSave } from '../state.js';
 import { clamp, rand } from '../utils.js';
-import { refreshOpenWindows } from '../windowManager.js';
 import { faker } from 'https://cdn.jsdelivr.net/npm/@faker-js/faker@8.3.1/+esm';
 
 export function renderEmigrate(container) {
@@ -15,28 +14,28 @@ export function renderEmigrate(container) {
   btn.addEventListener('click', () => {
     const cost = 2000;
     if (game.money < cost) {
-      addLog('Emigration costs $2,000. Not enough money.');
-      refreshOpenWindows();
-      saveGame();
+      applyAndSave(() => {
+        addLog('Emigration costs $2,000. Not enough money.');
+      });
       return;
     }
-    game.money -= cost;
-    const oldCity = game.city;
-    const oldCountry = game.country;
-    const newCity = faker.location.city();
-    const newCountry = faker.location.country();
-    const happinessGain = rand(5, 15);
-    const healthLoss = rand(0, 5);
-    game.city = newCity;
-    game.country = newCountry;
-    game.happiness = clamp(game.happiness + happinessGain);
-    game.health = clamp(game.health - healthLoss);
-    let logMsg = `You emigrated from ${oldCity}, ${oldCountry} to ${newCity}, ${newCountry}. +${happinessGain} Happiness`;
-    if (healthLoss > 0) logMsg += `, -${healthLoss} Health`;
-    logMsg += '.';
-    addLog(logMsg);
-    refreshOpenWindows();
-    saveGame();
+    applyAndSave(() => {
+      game.money -= cost;
+      const oldCity = game.city;
+      const oldCountry = game.country;
+      const newCity = faker.location.city();
+      const newCountry = faker.location.country();
+      const happinessGain = rand(5, 15);
+      const healthLoss = rand(0, 5);
+      game.city = newCity;
+      game.country = newCountry;
+      game.happiness = clamp(game.happiness + happinessGain);
+      game.health = clamp(game.health - healthLoss);
+      let logMsg = `You emigrated from ${oldCity}, ${oldCountry} to ${newCity}, ${newCountry}. +${happinessGain} Happiness`;
+      if (healthLoss > 0) logMsg += `, -${healthLoss} Health`;
+      logMsg += '.';
+      addLog(logMsg);
+    });
   });
 
   container.appendChild(btn);

--- a/activities/fertility.js
+++ b/activities/fertility.js
@@ -1,5 +1,4 @@
-import { game, addLog, saveGame } from '../state.js';
-import { refreshOpenWindows } from '../windowManager.js';
+import { game, addLog, applyAndSave } from '../state.js';
 import { faker } from 'https://cdn.jsdelivr.net/npm/@faker-js/faker@8.3.1/+esm';
 
 const TREATMENTS = [
@@ -20,18 +19,18 @@ export function renderFertility(container) {
     }
     btn.addEventListener('click', () => {
       if (game.money < t.cost) return;
-      game.money -= t.cost;
-      if (Math.random() < t.success) {
-        const name = faker.person.firstName();
-        const child = { name, age: 0, happiness: 90 };
-        if (!game.children) game.children = [];
-        game.children.push(child);
-        addLog(`Fertility treatment succeeded! You welcomed ${name}.`);
-      } else {
-        addLog('Fertility treatment failed.');
-      }
-      refreshOpenWindows();
-      saveGame();
+      applyAndSave(() => {
+        game.money -= t.cost;
+        if (Math.random() < t.success) {
+          const name = faker.person.firstName();
+          const child = { name, age: 0, happiness: 90 };
+          if (!game.children) game.children = [];
+          game.children.push(child);
+          addLog(`Fertility treatment succeeded! You welcomed ${name}.`);
+        } else {
+          addLog('Fertility treatment failed.');
+        }
+      });
     });
     wrap.appendChild(btn);
   }

--- a/activities/gamble.js
+++ b/activities/gamble.js
@@ -1,6 +1,6 @@
-import { game, addLog, saveGame } from '../state.js';
+import { game, addLog, applyAndSave } from '../state.js';
 import { rand } from '../utils.js';
-import { refreshOpenWindows, openWindow } from '../windowManager.js';
+import { openWindow } from '../windowManager.js';
 
 export { openWindow };
 
@@ -24,23 +24,23 @@ export function renderGamble(container) {
     const bet = Math.floor(Number(input.value));
     if (bet <= 0) return;
     if (game.money < bet) {
-      addLog('Not enough money to bet.');
-      refreshOpenWindows();
-      saveGame();
+      applyAndSave(() => {
+        addLog('Not enough money to bet.');
+      });
       return;
     }
-    game.money -= bet;
-    if (rand(0, 1) === 1) {
-      const payout = bet * 2;
-      game.money += payout;
-      addLog(`You won $${payout}.`);
-      result.textContent = `Result: Won $${payout}`;
-    } else {
-      addLog(`You lost $${bet}.`);
-      result.textContent = 'Result: Loss';
-    }
-    refreshOpenWindows();
-    saveGame();
+    applyAndSave(() => {
+      game.money -= bet;
+      if (rand(0, 1) === 1) {
+        const payout = bet * 2;
+        game.money += payout;
+        addLog(`You won $${payout}.`);
+        result.textContent = `Result: Won $${payout}`;
+      } else {
+        addLog(`You lost $${bet}.`);
+        result.textContent = 'Result: Loss';
+      }
+    });
   });
 
   wrap.appendChild(input);

--- a/activities/horseRacing.js
+++ b/activities/horseRacing.js
@@ -1,6 +1,6 @@
-import { game, addLog, saveGame } from '../state.js';
+import { game, addLog, applyAndSave } from '../state.js';
 import { rand, clamp } from '../utils.js';
-import { refreshOpenWindows, openWindow } from '../windowManager.js';
+import { openWindow } from '../windowManager.js';
 
 export { openWindow };
 
@@ -42,35 +42,35 @@ export function renderHorseRacing(container) {
   btn.addEventListener('click', () => {
     const bet = Math.max(1, parseInt(betInput.value, 10) || 0);
     if (game.money < bet) {
-      addLog('Not enough money to bet on horse racing.');
-      refreshOpenWindows();
-      saveGame();
+      applyAndSave(() => {
+        addLog('Not enough money to bet on horse racing.');
+      });
       return;
     }
-    game.money -= bet;
-    const choice = HORSES[parseInt(select.value, 10)];
-    const total = HORSES.reduce((s, h) => s + h.weight, 0);
-    let roll = rand(1, total);
-    let winner = HORSES[0];
-    for (const h of HORSES) {
-      if ((roll -= h.weight) <= 0) {
-        winner = h;
-        break;
+    applyAndSave(() => {
+      game.money -= bet;
+      const choice = HORSES[parseInt(select.value, 10)];
+      const total = HORSES.reduce((s, h) => s + h.weight, 0);
+      let roll = rand(1, total);
+      let winner = HORSES[0];
+      for (const h of HORSES) {
+        if ((roll -= h.weight) <= 0) {
+          winner = h;
+          break;
+        }
       }
-    }
-    if (winner === choice) {
-      const payout = bet * choice.odds;
-      game.money += payout;
-      game.happiness = clamp(game.happiness + 4);
-      addLog(`${choice.name} won! You earned $${payout}.`);
-      result.textContent = `Winner: ${winner.name} — You won $${payout}`;
-    } else {
-      game.happiness = clamp(game.happiness - 2);
-      addLog(`${choice.name} lost the race.`);
-      result.textContent = `Winner: ${winner.name} — You lost $${bet}`;
-    }
-    refreshOpenWindows();
-    saveGame();
+      if (winner === choice) {
+        const payout = bet * choice.odds;
+        game.money += payout;
+        game.happiness = clamp(game.happiness + 4);
+        addLog(`${choice.name} won! You earned $${payout}.`);
+        result.textContent = `Winner: ${winner.name} — You won $${payout}`;
+      } else {
+        game.happiness = clamp(game.happiness - 2);
+        addLog(`${choice.name} lost the race.`);
+        result.textContent = `Winner: ${winner.name} — You lost $${bet}`;
+      }
+    });
   });
 
   container.appendChild(wrap);

--- a/activities/identity.js
+++ b/activities/identity.js
@@ -1,6 +1,5 @@
-import { game, addLog, saveGame } from '../state.js';
+import { game, addLog, applyAndSave } from '../state.js';
 import { rand, clamp } from '../utils.js';
-import { refreshOpenWindows } from '../windowManager.js';
 import { faker } from 'https://cdn.jsdelivr.net/npm/@faker-js/faker@8.3.1/+esm';
 
 export function renderIdentity(container) {
@@ -16,31 +15,31 @@ export function renderIdentity(container) {
   theftBtn.textContent = 'Commit Identity Theft';
   theftBtn.addEventListener('click', () => {
     if (game.inJail) {
-      addLog('You cannot attempt this in jail.');
-      refreshOpenWindows();
-      saveGame();
+      applyAndSave(() => {
+        addLog('You cannot attempt this in jail.');
+      });
       return;
     }
-    const roll = rand(1, 100);
-    if (roll <= 50) {
-      const amount = rand(1000, 8000);
-      game.money += amount;
-      game.happiness = clamp(game.happiness + rand(1, 3));
-      addLog(`Identity theft succeeded. You gained $${amount.toLocaleString()}.`);
-    } else {
-      if (rand(1, 100) <= 60) {
-        game.inJail = true;
-        game.jailYears = rand(1, 3);
-        addLog(`Identity theft failed. Jailed for ${game.jailYears} year(s).`);
+    applyAndSave(() => {
+      const roll = rand(1, 100);
+      if (roll <= 50) {
+        const amount = rand(1000, 8000);
+        game.money += amount;
+        game.happiness = clamp(game.happiness + rand(1, 3));
+        addLog(`Identity theft succeeded. You gained $${amount.toLocaleString()}.`);
       } else {
-        const fine = rand(200, 800);
-        game.money = Math.max(game.money - fine, 0);
-        game.health = clamp(game.health - rand(1, 4));
-        addLog(`Identity theft failed. You paid $${fine} in fines and were roughed up.`);
+        if (rand(1, 100) <= 60) {
+          game.inJail = true;
+          game.jailYears = rand(1, 3);
+          addLog(`Identity theft failed. Jailed for ${game.jailYears} year(s).`);
+        } else {
+          const fine = rand(200, 800);
+          game.money = Math.max(game.money - fine, 0);
+          game.health = clamp(game.health - rand(1, 4));
+          addLog(`Identity theft failed. You paid $${fine} in fines and were roughed up.`);
+        }
       }
-    }
-    refreshOpenWindows();
-    saveGame();
+    });
   });
   wrap.appendChild(theftBtn);
 
@@ -50,22 +49,22 @@ export function renderIdentity(container) {
   legalBtn.addEventListener('click', () => {
     const cost = 150;
     if (game.money < cost) {
-      addLog('Name change costs $150. Not enough money.');
-      refreshOpenWindows();
-      saveGame();
+      applyAndSave(() => {
+        addLog('Name change costs $150. Not enough money.');
+      });
       return;
     }
-    game.money -= cost;
-    const oldName = game.name;
-    const first = faker.person.firstName(
-      game.gender === 'Male' ? 'male' : game.gender === 'Female' ? 'female' : undefined
-    );
-    const last = faker.person.lastName();
-    game.name = `${first} ${last}`;
-    game.happiness = clamp(game.happiness + rand(1, 3));
-    addLog(`You legally changed your name from ${oldName} to ${game.name}.`);
-    refreshOpenWindows();
-    saveGame();
+    applyAndSave(() => {
+      game.money -= cost;
+      const oldName = game.name;
+      const first = faker.person.firstName(
+        game.gender === 'Male' ? 'male' : game.gender === 'Female' ? 'female' : undefined
+      );
+      const last = faker.person.lastName();
+      game.name = `${first} ${last}`;
+      game.happiness = clamp(game.happiness + rand(1, 3));
+      addLog(`You legally changed your name from ${oldName} to ${game.name}.`);
+    });
   });
   wrap.appendChild(legalBtn);
 

--- a/activities/lawsuit.js
+++ b/activities/lawsuit.js
@@ -1,6 +1,5 @@
-import { game, addLog, saveGame } from '../state.js';
+import { game, addLog, applyAndSave } from '../state.js';
 import { rand, clamp } from '../utils.js';
-import { refreshOpenWindows } from '../windowManager.js';
 
 export function renderLawsuit(container) {
   const wrap = document.createElement('div');
@@ -16,23 +15,23 @@ export function renderLawsuit(container) {
   fileBtn.addEventListener('click', () => {
     const cost = 5000;
     if (game.money < cost) {
-      addLog('Filing a lawsuit costs $5,000. Not enough money.');
-      refreshOpenWindows();
-      saveGame();
+      applyAndSave(() => {
+        addLog('Filing a lawsuit costs $5,000. Not enough money.');
+      });
       return;
     }
-    game.money -= cost;
-    if (rand(0, 1) === 1) {
-      const award = 25000;
-      game.money += award;
-      game.happiness = clamp(game.happiness + 5);
-      addLog(`You won the lawsuit and received $${award.toLocaleString()}.`);
-    } else {
-      game.happiness = clamp(game.happiness - 5);
-      addLog('You lost the lawsuit. The court dismissed your case.');
-    }
-    refreshOpenWindows();
-    saveGame();
+    applyAndSave(() => {
+      game.money -= cost;
+      if (rand(0, 1) === 1) {
+        const award = 25000;
+        game.money += award;
+        game.happiness = clamp(game.happiness + 5);
+        addLog(`You won the lawsuit and received $${award.toLocaleString()}.`);
+      } else {
+        game.happiness = clamp(game.happiness - 5);
+        addLog('You lost the lawsuit. The court dismissed your case.');
+      }
+    });
   });
   wrap.appendChild(fileBtn);
 
@@ -42,23 +41,23 @@ export function renderLawsuit(container) {
   defendBtn.addEventListener('click', () => {
     const cost = 3000;
     if (game.money < cost) {
-      addLog('Defending a lawsuit costs $3,000. Not enough money.');
-      refreshOpenWindows();
-      saveGame();
+      applyAndSave(() => {
+        addLog('Defending a lawsuit costs $3,000. Not enough money.');
+      });
       return;
     }
-    game.money -= cost;
-    if (rand(0, 1) === 1) {
-      game.happiness = clamp(game.happiness + 2);
-      addLog('You successfully defended the lawsuit.');
-    } else {
-      const damages = 10000;
-      game.money -= damages;
-      game.happiness = clamp(game.happiness - 8);
-      addLog(`You lost the lawsuit and paid $${damages.toLocaleString()} in damages.`);
-    }
-    refreshOpenWindows();
-    saveGame();
+    applyAndSave(() => {
+      game.money -= cost;
+      if (rand(0, 1) === 1) {
+        game.happiness = clamp(game.happiness + 2);
+        addLog('You successfully defended the lawsuit.');
+      } else {
+        const damages = 10000;
+        game.money -= damages;
+        game.happiness = clamp(game.happiness - 8);
+        addLog(`You lost the lawsuit and paid $${damages.toLocaleString()} in damages.`);
+      }
+    });
   });
   wrap.appendChild(defendBtn);
 

--- a/activities/licenses.js
+++ b/activities/licenses.js
@@ -1,5 +1,4 @@
-import { game, addLog, saveGame } from '../state.js';
-import { refreshOpenWindows } from '../windowManager.js';
+import { game, addLog, applyAndSave } from '../state.js';
 
 const LICENSE_OPTIONS = [
   { type: "Driver's License", cost: 50 },
@@ -19,11 +18,11 @@ export function renderLicenses(container) {
     btn.disabled = game.money < opt.cost || game.licenses.includes(opt.type);
     btn.addEventListener('click', () => {
       if (game.money < opt.cost || game.licenses.includes(opt.type)) return;
-      game.money -= opt.cost;
-      game.licenses.push(opt.type);
-      addLog(`You obtained a ${opt.type}.`);
-      refreshOpenWindows();
-      saveGame();
+      applyAndSave(() => {
+        game.money -= opt.cost;
+        game.licenses.push(opt.type);
+        addLog(`You obtained a ${opt.type}.`);
+      });
     });
     wrap.appendChild(btn);
   }

--- a/activities/lottery.js
+++ b/activities/lottery.js
@@ -1,6 +1,6 @@
-import { game, addLog, saveGame } from '../state.js';
+import { game, addLog, applyAndSave } from '../state.js';
 import { rand, clamp } from '../utils.js';
-import { openWindow, refreshOpenWindows } from '../windowManager.js';
+import { openWindow } from '../windowManager.js';
 
 export { openWindow };
 
@@ -12,29 +12,29 @@ export function renderLottery(container) {
   btn.disabled = game.money < 5;
   btn.addEventListener('click', () => {
     if (game.money < 5) return;
-    game.money -= 5;
-    const roll = rand(1, 100);
-    let prize = 0;
-    let mood = -2;
-    let msg = 'You bought a lottery ticket but won nothing.';
-    if (roll === 1) {
-      prize = 10000;
-      mood = 20;
-      msg = `Jackpot! You won $${prize.toLocaleString()}.`;
-    } else if (roll <= 5) {
-      prize = 1000;
-      mood = 8;
-      msg = `You won $${prize.toLocaleString()}.`;
-    } else if (roll <= 20) {
-      prize = 100;
-      mood = 3;
-      msg = `You won $${prize}.`;
-    }
-    game.money += prize;
-    game.happiness = clamp(game.happiness + mood);
-    addLog(msg);
-    refreshOpenWindows();
-    saveGame();
+    applyAndSave(() => {
+      game.money -= 5;
+      const roll = rand(1, 100);
+      let prize = 0;
+      let mood = -2;
+      let msg = 'You bought a lottery ticket but won nothing.';
+      if (roll === 1) {
+        prize = 10000;
+        mood = 20;
+        msg = `Jackpot! You won $${prize.toLocaleString()}.`;
+      } else if (roll <= 5) {
+        prize = 1000;
+        mood = 8;
+        msg = `You won $${prize.toLocaleString()}.`;
+      } else if (roll <= 20) {
+        prize = 100;
+        mood = 3;
+        msg = `You won $${prize}.`;
+      }
+      game.money += prize;
+      game.happiness = clamp(game.happiness + mood);
+      addLog(msg);
+    });
   });
   wrap.appendChild(btn);
   container.appendChild(wrap);

--- a/activities/love.js
+++ b/activities/love.js
@@ -1,6 +1,5 @@
-import { game, addLog, saveGame } from '../state.js';
+import { game, addLog, applyAndSave } from '../state.js';
 import { rand, clamp } from '../utils.js';
-import { refreshOpenWindows } from '../windowManager.js';
 import { faker } from 'https://cdn.jsdelivr.net/npm/@faker-js/faker@8.3.1/+esm';
 
 export function renderLove(container) {
@@ -28,10 +27,10 @@ export function renderLove(container) {
       btn.textContent = 'Break up';
       btn.style.marginLeft = 'auto';
       btn.addEventListener('click', () => {
-        game.relationships.splice(i, 1);
-        addLog(`You broke up with ${rel.name}.`);
-        refreshOpenWindows();
-        saveGame();
+        applyAndSave(() => {
+          game.relationships.splice(i, 1);
+          addLog(`You broke up with ${rel.name}.`);
+        });
       });
       row.appendChild(btn);
 
@@ -44,12 +43,12 @@ export function renderLove(container) {
   findBtn.className = 'btn';
   findBtn.textContent = 'Find Partner';
   findBtn.addEventListener('click', () => {
-    const name = `${faker.person.firstName()} ${faker.person.lastName()}`;
-    const partner = { name, happiness: rand(40, 80) };
-    game.relationships.push(partner);
-    addLog(`You started dating ${name}.`);
-    refreshOpenWindows();
-    saveGame();
+    applyAndSave(() => {
+      const name = `${faker.person.firstName()} ${faker.person.lastName()}`;
+      const partner = { name, happiness: rand(40, 80) };
+      game.relationships.push(partner);
+      addLog(`You started dating ${name}.`);
+    });
   });
   wrap.appendChild(findBtn);
 
@@ -57,15 +56,15 @@ export function renderLove(container) {
 }
 
 export function tickRelationships() {
-  for (let i = game.relationships.length - 1; i >= 0; i--) {
-    const r = game.relationships[i];
-    r.happiness = clamp(r.happiness + rand(-10, 5));
-    if (r.happiness <= 0) {
-      addLog(`${r.name} left you.`);
-      game.relationships.splice(i, 1);
+  applyAndSave(() => {
+    for (let i = game.relationships.length - 1; i >= 0; i--) {
+      const r = game.relationships[i];
+      r.happiness = clamp(r.happiness + rand(-10, 5));
+      if (r.happiness <= 0) {
+        addLog(`${r.name} left you.`);
+        game.relationships.splice(i, 1);
+      }
     }
-  }
-  refreshOpenWindows();
-  saveGame();
+  });
 }
 

--- a/activities/luxuryLifestyle.js
+++ b/activities/luxuryLifestyle.js
@@ -1,6 +1,5 @@
-import { game, addLog, saveGame } from '../state.js';
+import { game, addLog, applyAndSave } from '../state.js';
 import { clamp } from '../utils.js';
-import { refreshOpenWindows } from '../windowManager.js';
 
 export function renderLuxuryLifestyle(container) {
   const head = document.createElement('div');
@@ -23,17 +22,17 @@ export function renderLuxuryLifestyle(container) {
     btn.disabled = game.money < item.cost;
     btn.addEventListener('click', () => {
       if (game.money < item.cost) {
-        addLog(`${item.name} costs $${item.cost.toLocaleString()}. Not enough money.`);
-        refreshOpenWindows();
-        saveGame();
+        applyAndSave(() => {
+          addLog(`${item.name} costs $${item.cost.toLocaleString()}. Not enough money.`);
+        });
         return;
       }
-      game.money -= item.cost;
-      game.happiness = clamp(game.happiness + item.happiness);
-      game.looks = clamp(game.looks + item.looks);
-      addLog(`You bought a ${item.name}. +${item.happiness} Happiness, +${item.looks} Looks.`);
-      refreshOpenWindows();
-      saveGame();
+      applyAndSave(() => {
+        game.money -= item.cost;
+        game.happiness = clamp(game.happiness + item.happiness);
+        game.looks = clamp(game.looks + item.looks);
+        addLog(`You bought a ${item.name}. +${item.happiness} Happiness, +${item.looks} Looks.`);
+      });
     });
     list.appendChild(btn);
   }

--- a/activities/mindAndWork.js
+++ b/activities/mindAndWork.js
@@ -1,6 +1,5 @@
-import { game, addLog, saveGame } from '../state.js';
+import { game, addLog, applyAndSave } from '../state.js';
 import { clamp, rand } from '../utils.js';
-import { refreshOpenWindows } from '../windowManager.js';
 
 export function renderMindAndWork(container) {
   const wrap = document.createElement('div');
@@ -17,11 +16,11 @@ export function renderMindAndWork(container) {
 
   wrap.appendChild(
     mk('Meditate', () => {
-      const gain = rand(2, 5);
-      game.happiness = clamp(game.happiness + gain);
-      addLog(`You meditated. +${gain} Happiness.`);
-      refreshOpenWindows();
-      saveGame();
+      applyAndSave(() => {
+        const gain = rand(2, 5);
+        game.happiness = clamp(game.happiness + gain);
+        addLog(`You meditated. +${gain} Happiness.`);
+      });
     })
   );
 
@@ -29,16 +28,17 @@ export function renderMindAndWork(container) {
     mk('Productivity Course ($100)', () => {
       const cost = 100;
       if (game.money < cost) {
-        addLog(`Course costs $${cost}. Not enough money.`);
-        saveGame();
+        applyAndSave(() => {
+          addLog(`Course costs $${cost}. Not enough money.`);
+        });
         return;
       }
-      game.money -= cost;
-      const gain = rand(4, 8);
-      game.smarts = clamp(game.smarts + gain);
-      addLog(`You took a productivity course. +${gain} Smarts.`);
-      refreshOpenWindows();
-      saveGame();
+      applyAndSave(() => {
+        game.money -= cost;
+        const gain = rand(4, 8);
+        game.smarts = clamp(game.smarts + gain);
+        addLog(`You took a productivity course. +${gain} Smarts.`);
+      });
     })
   );
 

--- a/activities/movieTheater.js
+++ b/activities/movieTheater.js
@@ -1,6 +1,6 @@
-import { game, addLog, saveGame } from '../state.js';
+import { game, addLog, applyAndSave } from '../state.js';
 import { rand, clamp } from '../utils.js';
-import { refreshOpenWindows, openWindow as windowOpen } from '../windowManager.js';
+import { openWindow as windowOpen } from '../windowManager.js';
 
 export { windowOpen as openWindow };
 
@@ -32,14 +32,14 @@ export function renderMovieTheater(container) {
   if (game.money < TICKET_COST) btn.disabled = true;
   btn.addEventListener('click', () => {
     if (game.money < TICKET_COST) return;
-    game.money -= TICKET_COST;
-    const event = EVENTS[rand(0, EVENTS.length - 1)];
-    game.happiness = clamp(game.happiness + event.happiness);
-    if (event.money) game.money += event.money;
-    addLog(event.text);
-    result.textContent = event.text;
-    refreshOpenWindows();
-    saveGame();
+    applyAndSave(() => {
+      game.money -= TICKET_COST;
+      const event = EVENTS[rand(0, EVENTS.length - 1)];
+      game.happiness = clamp(game.happiness + event.happiness);
+      if (event.money) game.money += event.money;
+      addLog(event.text);
+      result.textContent = event.text;
+    });
   });
 
   wrap.appendChild(btn);

--- a/activities/nightlife.js
+++ b/activities/nightlife.js
@@ -1,6 +1,5 @@
-import { game, addLog, saveGame } from '../state.js';
+import { game, addLog, applyAndSave } from '../state.js';
 import { rand, clamp } from '../utils.js';
-import { refreshOpenWindows } from '../windowManager.js';
 
 export function renderNightlife(container) {
   const wrap = document.createElement('div');
@@ -18,16 +17,17 @@ export function renderNightlife(container) {
     mk('Go Clubbing ($20)', () => {
       const cost = 20;
       if (game.money < cost) {
-        addLog('Not enough money to go clubbing.');
-        saveGame();
+        applyAndSave(() => {
+          addLog('Not enough money to go clubbing.');
+        });
         return;
       }
-      game.money -= cost;
-      game.happiness = clamp(game.happiness + rand(4, 8));
-      game.health = clamp(game.health - rand(0, 4));
-      addLog('You danced the night away at the club.');
-      refreshOpenWindows();
-      saveGame();
+      applyAndSave(() => {
+        game.money -= cost;
+        game.happiness = clamp(game.happiness + rand(4, 8));
+        game.health = clamp(game.health - rand(0, 4));
+        addLog('You danced the night away at the club.');
+      });
     })
   );
 
@@ -35,16 +35,17 @@ export function renderNightlife(container) {
     mk('Bar Hopping ($15)', () => {
       const cost = 15;
       if (game.money < cost) {
-        addLog('Not enough money to go bar hopping.');
-        saveGame();
+        applyAndSave(() => {
+          addLog('Not enough money to go bar hopping.');
+        });
         return;
       }
-      game.money -= cost;
-      game.happiness = clamp(game.happiness + rand(2, 6));
-      game.health = clamp(game.health - rand(0, 3));
-      addLog('You enjoyed a night of bar hopping.');
-      refreshOpenWindows();
-      saveGame();
+      applyAndSave(() => {
+        game.money -= cost;
+        game.happiness = clamp(game.happiness + rand(2, 6));
+        game.health = clamp(game.health - rand(0, 3));
+        addLog('You enjoyed a night of bar hopping.');
+      });
     })
   );
 

--- a/activities/outdoorLifestyle.js
+++ b/activities/outdoorLifestyle.js
@@ -1,6 +1,5 @@
-import { game, addLog, saveGame } from '../state.js';
+import { game, addLog, applyAndSave } from '../state.js';
 import { clamp, rand } from '../utils.js';
-import { refreshOpenWindows } from '../windowManager.js';
 
 export function renderOutdoorLifestyle(container) {
   const wrap = document.createElement('div');
@@ -30,14 +29,14 @@ export function renderOutdoorLifestyle(container) {
     }
     btn.addEventListener('click', () => {
       if (opt.cost && game.money < opt.cost) return;
-      if (opt.cost) game.money -= opt.cost;
-      const healthGain = rand(opt.health[0], opt.health[1]);
-      const happinessGain = rand(opt.happiness[0], opt.happiness[1]);
-      game.health = clamp(game.health + healthGain);
-      game.happiness = clamp(game.happiness + happinessGain);
-      addLog(`You ${opt.log}. +${healthGain} Health, +${happinessGain} Happiness.`);
-      refreshOpenWindows();
-      saveGame();
+      applyAndSave(() => {
+        if (opt.cost) game.money -= opt.cost;
+        const healthGain = rand(opt.health[0], opt.health[1]);
+        const happinessGain = rand(opt.happiness[0], opt.happiness[1]);
+        game.health = clamp(game.health + healthGain);
+        game.happiness = clamp(game.happiness + happinessGain);
+        addLog(`You ${opt.log}. +${healthGain} Health, +${happinessGain} Happiness.`);
+      });
     });
     wrap.appendChild(btn);
   }

--- a/activities/pets.js
+++ b/activities/pets.js
@@ -1,5 +1,5 @@
-import { game, addLog, saveGame } from '../state.js';
-import { refreshOpenWindows, openWindow } from '../windowManager.js';
+import { game, addLog, applyAndSave } from '../state.js';
+import { openWindow } from '../windowManager.js';
 
 export { openWindow };
 
@@ -27,16 +27,16 @@ export function renderPets(container) {
     btn.disabled = game.money < a.cost;
     btn.addEventListener('click', () => {
       if (game.money < a.cost) {
-        addLog('You cannot afford that pet.');
-        refreshOpenWindows();
-        saveGame();
+        applyAndSave(() => {
+          addLog('You cannot afford that pet.');
+        });
         return;
       }
-      game.money -= a.cost;
-      game.pets.push({ type: a.type, age: 0, happiness: 70 });
-      addLog(`You adopted a ${a.type}.`);
-      refreshOpenWindows();
-      saveGame();
+      applyAndSave(() => {
+        game.money -= a.cost;
+        game.pets.push({ type: a.type, age: 0, happiness: 70 });
+        addLog(`You adopted a ${a.type}.`);
+      });
     });
     list.appendChild(btn);
   }
@@ -59,21 +59,21 @@ export function renderPets(container) {
       play.className = 'btn';
       play.textContent = 'Play';
       play.addEventListener('click', () => {
-        pet.happiness = Math.min(pet.happiness + 10, 100);
-        addLog(`You played with your ${pet.type}.`);
-        refreshOpenWindows();
-        saveGame();
+        applyAndSave(() => {
+          pet.happiness = Math.min(pet.happiness + 10, 100);
+          addLog(`You played with your ${pet.type}.`);
+        });
       });
       actions.appendChild(play);
       const ageBtn = document.createElement('button');
       ageBtn.className = 'btn';
       ageBtn.textContent = 'Age';
       ageBtn.addEventListener('click', () => {
-        pet.age += 1;
-        pet.happiness = Math.max(pet.happiness - 5, 0);
-        addLog(`Your ${pet.type} aged a year.`);
-        refreshOpenWindows();
-        saveGame();
+        applyAndSave(() => {
+          pet.age += 1;
+          pet.happiness = Math.max(pet.happiness - 5, 0);
+          addLog(`Your ${pet.type} aged a year.`);
+        });
       });
       actions.appendChild(ageBtn);
       row.appendChild(actions);

--- a/activities/plasticSurgery.js
+++ b/activities/plasticSurgery.js
@@ -1,6 +1,5 @@
-import { game, addLog, saveGame } from '../state.js';
+import { game, addLog, applyAndSave } from '../state.js';
 import { clamp } from '../utils.js';
-import { refreshOpenWindows } from '../windowManager.js';
 
 export function renderPlasticSurgery(container) {
   const wrap = document.createElement('div');
@@ -19,16 +18,16 @@ export function renderPlasticSurgery(container) {
     btn.textContent = `${p.name} ($${p.cost.toLocaleString()})`;
     btn.addEventListener('click', () => {
       if (game.money < p.cost) {
-        addLog(`Not enough money for ${p.name} ($${p.cost.toLocaleString()}).`);
-        refreshOpenWindows();
-        saveGame();
+        applyAndSave(() => {
+          addLog(`Not enough money for ${p.name} ($${p.cost.toLocaleString()}).`);
+        });
         return;
       }
-      game.money -= p.cost;
-      game.looks = clamp(game.looks + p.gain);
-      addLog(`You underwent a ${p.name}. (-$${p.cost.toLocaleString()}, +Looks)`);
-      refreshOpenWindows();
-      saveGame();
+      applyAndSave(() => {
+        game.money -= p.cost;
+        game.looks = clamp(game.looks + p.gain);
+        addLog(`You underwent a ${p.name}. (-$${p.cost.toLocaleString()}, +Looks)`);
+      });
     });
     wrap.appendChild(btn);
   }

--- a/activities/raceTracks.js
+++ b/activities/raceTracks.js
@@ -1,6 +1,6 @@
-import { game, addLog, saveGame } from '../state.js';
+import { game, addLog, applyAndSave } from '../state.js';
 import { rand, clamp } from '../utils.js';
-import { openWindow, refreshOpenWindows } from '../windowManager.js';
+import { openWindow } from '../windowManager.js';
 
 export { openWindow };
 
@@ -22,21 +22,21 @@ export function renderRaceTracks(container) {
     }
     btn.addEventListener('click', () => {
       if (game.money < track.cost) return;
-      game.money -= track.cost;
-      const roll = rand(1, 100);
-      let msg;
-      if (roll <= track.chance) {
-        const winnings = track.cost * track.multiplier;
-        game.money += winnings;
-        game.happiness = clamp(game.happiness + 5);
-        msg = `You won $${winnings.toLocaleString()} at the ${track.label}.`;
-      } else {
-        game.happiness = clamp(game.happiness - 5);
-        msg = `You lost your bet at the ${track.label}.`;
-      }
-      addLog(msg);
-      refreshOpenWindows();
-      saveGame();
+      applyAndSave(() => {
+        game.money -= track.cost;
+        const roll = rand(1, 100);
+        let msg;
+        if (roll <= track.chance) {
+          const winnings = track.cost * track.multiplier;
+          game.money += winnings;
+          game.happiness = clamp(game.happiness + 5);
+          msg = `You won $${winnings.toLocaleString()} at the ${track.label}.`;
+        } else {
+          game.happiness = clamp(game.happiness - 5);
+          msg = `You lost your bet at the ${track.label}.`;
+        }
+        addLog(msg);
+      });
     });
     wrap.appendChild(btn);
   }

--- a/activities/racing.js
+++ b/activities/racing.js
@@ -1,6 +1,5 @@
-import { game, addLog, saveGame } from '../state.js';
+import { game, addLog, applyAndSave } from '../state.js';
 import { rand, clamp } from '../utils.js';
-import { refreshOpenWindows } from '../windowManager.js';
 
 export function renderRacing(container) {
   const wrap = document.createElement('div');
@@ -14,19 +13,19 @@ export function renderRacing(container) {
   vehicleBtn.className = 'btn';
   vehicleBtn.textContent = 'Race Vehicles';
   vehicleBtn.addEventListener('click', () => {
-    if (rand(0, 1) === 0) {
-      const prize = rand(200, 500);
-      game.money += prize;
-      game.happiness = clamp(game.happiness + rand(5, 10));
-      addLog(`You won a vehicle race and earned $${prize}.`);
-    } else {
-      const dmg = rand(5, 15);
-      game.health = clamp(game.health - dmg);
-      game.happiness = clamp(game.happiness - rand(5, 10));
-      addLog(`You crashed during a vehicle race. -${dmg} Health.`);
-    }
-    refreshOpenWindows();
-    saveGame();
+    applyAndSave(() => {
+      if (rand(0, 1) === 0) {
+        const prize = rand(200, 500);
+        game.money += prize;
+        game.happiness = clamp(game.happiness + rand(5, 10));
+        addLog(`You won a vehicle race and earned $${prize}.`);
+      } else {
+        const dmg = rand(5, 15);
+        game.health = clamp(game.health - dmg);
+        game.happiness = clamp(game.happiness - rand(5, 10));
+        addLog(`You crashed during a vehicle race. -${dmg} Health.`);
+      }
+    });
   });
   wrap.appendChild(vehicleBtn);
 
@@ -34,19 +33,19 @@ export function renderRacing(container) {
   footBtn.className = 'btn';
   footBtn.textContent = 'Race on Foot';
   footBtn.addEventListener('click', () => {
-    if (rand(0, 1) === 0) {
-      const gain = rand(5, 10);
-      game.health = clamp(game.health + gain);
-      game.happiness = clamp(game.happiness + rand(2, 6));
-      addLog(`You won the foot race. +${gain} Health.`);
-    } else {
-      const loss = rand(2, 7);
-      game.health = clamp(game.health - loss);
-      game.happiness = clamp(game.happiness - rand(1, 4));
-      addLog(`You lost the foot race. -${loss} Health.`);
-    }
-    refreshOpenWindows();
-    saveGame();
+    applyAndSave(() => {
+      if (rand(0, 1) === 0) {
+        const gain = rand(5, 10);
+        game.health = clamp(game.health + gain);
+        game.happiness = clamp(game.happiness + rand(2, 6));
+        addLog(`You won the foot race. +${gain} Health.`);
+      } else {
+        const loss = rand(2, 7);
+        game.health = clamp(game.health - loss);
+        game.happiness = clamp(game.happiness - rand(1, 4));
+        addLog(`You lost the foot race. -${loss} Health.`);
+      }
+    });
   });
   wrap.appendChild(footBtn);
 

--- a/activities/rehab.js
+++ b/activities/rehab.js
@@ -1,6 +1,5 @@
-import { game, addLog, saveGame } from '../state.js';
+import { game, addLog, applyAndSave } from '../state.js';
 import { clamp, rand } from '../utils.js';
-import { refreshOpenWindows } from '../windowManager.js';
 
 export function renderRehab(container) {
   const wrap = document.createElement('div');
@@ -19,16 +18,17 @@ export function renderRehab(container) {
     mk('Therapy Session ($200)', () => {
       const cost = 200;
       if (game.money < cost) {
-        addLog(`Therapy session costs $${cost}. Not enough money.`);
-        saveGame();
+        applyAndSave(() => {
+          addLog(`Therapy session costs $${cost}. Not enough money.`);
+        });
         return;
       }
-      game.money -= cost;
-      game.health = clamp(game.health + rand(1, 3));
-      game.addiction = clamp(game.addiction - rand(2, 5));
-      addLog('Therapy session helped you recover. (+Health, -Addiction)');
-      refreshOpenWindows();
-      saveGame();
+      applyAndSave(() => {
+        game.money -= cost;
+        game.health = clamp(game.health + rand(1, 3));
+        game.addiction = clamp(game.addiction - rand(2, 5));
+        addLog('Therapy session helped you recover. (+Health, -Addiction)');
+      });
     })
   );
 
@@ -36,16 +36,17 @@ export function renderRehab(container) {
     mk('Detox Program ($500)', () => {
       const cost = 500;
       if (game.money < cost) {
-        addLog(`Detox program costs $${cost}. Not enough money.`);
-        saveGame();
+        applyAndSave(() => {
+          addLog(`Detox program costs $${cost}. Not enough money.`);
+        });
         return;
       }
-      game.money -= cost;
-      game.health = clamp(game.health + rand(4, 8));
-      game.addiction = clamp(game.addiction - rand(5, 15));
-      addLog('You completed a detox program. (+Health, -Addiction)');
-      refreshOpenWindows();
-      saveGame();
+      applyAndSave(() => {
+        game.money -= cost;
+        game.health = clamp(game.health + rand(4, 8));
+        game.addiction = clamp(game.addiction - rand(5, 15));
+        addLog('You completed a detox program. (+Health, -Addiction)');
+      });
     })
   );
 
@@ -53,16 +54,17 @@ export function renderRehab(container) {
     mk('Intensive Rehab ($1000)', () => {
       const cost = 1000;
       if (game.money < cost) {
-        addLog(`Intensive rehab costs $${cost}. Not enough money.`);
-        saveGame();
+        applyAndSave(() => {
+          addLog(`Intensive rehab costs $${cost}. Not enough money.`);
+        });
         return;
       }
-      game.money -= cost;
-      game.health = clamp(game.health + rand(8, 15));
-      game.addiction = clamp(game.addiction - rand(15, 30));
-      addLog('Intensive rehab significantly reduced your addiction. (+Health, -Addiction)');
-      refreshOpenWindows();
-      saveGame();
+      applyAndSave(() => {
+        game.money -= cost;
+        game.health = clamp(game.health + rand(8, 15));
+        game.addiction = clamp(game.addiction - rand(15, 30));
+        addLog('Intensive rehab significantly reduced your addiction. (+Health, -Addiction)');
+      });
     })
   );
 

--- a/activities/salonAndSpa.js
+++ b/activities/salonAndSpa.js
@@ -1,6 +1,5 @@
-import { game, addLog, saveGame } from '../state.js';
+import { game, addLog, applyAndSave } from '../state.js';
 import { clamp, rand } from '../utils.js';
-import { refreshOpenWindows } from '../windowManager.js';
 
 export function renderSalonAndSpa(container) {
   const wrap = document.createElement('div');
@@ -19,16 +18,17 @@ export function renderSalonAndSpa(container) {
     mk('Haircut ($40)', () => {
       const cost = 40;
       if (game.money < cost) {
-        addLog(`Haircut costs $${cost}. Not enough money.`);
-        saveGame();
+        applyAndSave(() => {
+          addLog(`Haircut costs $${cost}. Not enough money.`);
+        });
         return;
       }
-      game.money -= cost;
-      game.happiness = clamp(game.happiness + rand(1, 4));
-      game.looks = clamp(game.looks + rand(1, 3));
-      addLog('You got a fresh haircut. (+Happiness, +Looks)');
-      refreshOpenWindows();
-      saveGame();
+      applyAndSave(() => {
+        game.money -= cost;
+        game.happiness = clamp(game.happiness + rand(1, 4));
+        game.looks = clamp(game.looks + rand(1, 3));
+        addLog('You got a fresh haircut. (+Happiness, +Looks)');
+      });
     })
   );
 
@@ -36,16 +36,17 @@ export function renderSalonAndSpa(container) {
     mk('Massage ($80)', () => {
       const cost = 80;
       if (game.money < cost) {
-        addLog(`Massage costs $${cost}. Not enough money.`);
-        saveGame();
+        applyAndSave(() => {
+          addLog(`Massage costs $${cost}. Not enough money.`);
+        });
         return;
       }
-      game.money -= cost;
-      game.health = clamp(game.health + rand(2, 6));
-      game.happiness = clamp(game.happiness + rand(2, 5));
-      addLog('The massage relaxed you. (+Health, +Happiness)');
-      refreshOpenWindows();
-      saveGame();
+      applyAndSave(() => {
+        game.money -= cost;
+        game.health = clamp(game.health + rand(2, 6));
+        game.happiness = clamp(game.happiness + rand(2, 5));
+        addLog('The massage relaxed you. (+Health, +Happiness)');
+      });
     })
   );
 

--- a/activities/secretAgent.js
+++ b/activities/secretAgent.js
@@ -1,5 +1,4 @@
-import { game, addLog, saveGame } from '../state.js';
-import { refreshOpenWindows } from '../windowManager.js';
+import { game, addLog, applyAndSave } from '../state.js';
 import { rand, clamp } from '../utils.js';
 
 const MISSIONS = [
@@ -60,14 +59,14 @@ export function renderSecretAgent(container) {
     btn.className = 'btn block';
     btn.textContent = m.label;
     btn.addEventListener('click', () => {
-      const success = rand(1, 100) <= 60;
-      if (success) {
-        m.success();
-      } else {
-        m.fail();
-      }
-      refreshOpenWindows();
-      saveGame();
+      applyAndSave(() => {
+        const success = rand(1, 100) <= 60;
+        if (success) {
+          m.success();
+        } else {
+          m.fail();
+        }
+      });
     });
     wrap.appendChild(btn);
   }

--- a/activities/shopping.js
+++ b/activities/shopping.js
@@ -1,6 +1,5 @@
-import { game, addLog, saveGame } from '../state.js';
+import { game, addLog, applyAndSave } from '../state.js';
 import { clamp, rand } from '../utils.js';
-import { refreshOpenWindows } from '../windowManager.js';
 
 const GOODS = [
   { name: 'Gourmet Chocolate', cost: 30, happiness: 4 },
@@ -23,25 +22,25 @@ export function renderShopping(container) {
     btn.disabled = game.money < item.cost;
     btn.addEventListener('click', () => {
       if (game.money < item.cost) {
-        addLog(`You cannot afford ${item.name}.`);
-        refreshOpenWindows();
-        saveGame();
+        applyAndSave(() => {
+          addLog(`You cannot afford ${item.name}.`);
+        });
         return;
       }
-      game.money -= item.cost;
-      let log = `You bought ${item.name}.`;
-      if (item.happiness) {
-        game.happiness = clamp(game.happiness + item.happiness);
-        log += ` +${item.happiness} Happiness.`;
-      }
-      if (item.money) {
-        const gain = typeof item.money === 'function' ? item.money() : item.money;
-        game.money += gain;
-        log += ` +$${gain}.`;
-      }
-      addLog(log);
-      refreshOpenWindows();
-      saveGame();
+      applyAndSave(() => {
+        game.money -= item.cost;
+        let log = `You bought ${item.name}.`;
+        if (item.happiness) {
+          game.happiness = clamp(game.happiness + item.happiness);
+          log += ` +${item.happiness} Happiness.`;
+        }
+        if (item.money) {
+          const gain = typeof item.money === 'function' ? item.money() : item.money;
+          game.money += gain;
+          log += ` +$${gain}.`;
+        }
+        addLog(log);
+      });
     });
     wrap.appendChild(btn);
   }

--- a/activities/socialMedia.js
+++ b/activities/socialMedia.js
@@ -1,6 +1,5 @@
-import { game, addLog, saveGame } from '../state.js';
+import { game, addLog, applyAndSave } from '../state.js';
 import { clamp, rand } from '../utils.js';
-import { refreshOpenWindows } from '../windowManager.js';
 
 export function renderSocialMedia(container) {
   if (typeof game.followers !== 'number') game.followers = 0;
@@ -21,14 +20,14 @@ export function renderSocialMedia(container) {
   post.className = 'btn';
   post.textContent = 'Post Update';
   post.addEventListener('click', () => {
-    const gained = rand(1, 20);
-    game.followers += gained;
-    const gain = rand(1, 3);
-    game.happiness = clamp(game.happiness + gain);
-    addLog(`You posted on social media and gained ${gained} followers.`);
-    count.textContent = `Followers: ${game.followers}`;
-    refreshOpenWindows();
-    saveGame();
+    applyAndSave(() => {
+      const gained = rand(1, 20);
+      game.followers += gained;
+      const gain = rand(1, 3);
+      game.happiness = clamp(game.happiness + gain);
+      addLog(`You posted on social media and gained ${gained} followers.`);
+      count.textContent = `Followers: ${game.followers}`;
+    });
   });
 
   const promote = document.createElement('button');
@@ -37,19 +36,19 @@ export function renderSocialMedia(container) {
   promote.addEventListener('click', () => {
     const cost = 100;
     if (game.money < cost) {
-      addLog('Promotion costs $100. Not enough money.');
-      refreshOpenWindows();
-      saveGame();
+      applyAndSave(() => {
+        addLog('Promotion costs $100. Not enough money.');
+      });
       return;
     }
-    game.money -= cost;
-    const gained = rand(50, 100);
-    game.followers += gained;
-    game.happiness = clamp(game.happiness + 5);
-    addLog(`You promoted your account and gained ${gained} followers.`);
-    count.textContent = `Followers: ${game.followers}`;
-    refreshOpenWindows();
-    saveGame();
+    applyAndSave(() => {
+      game.money -= cost;
+      const gained = rand(50, 100);
+      game.followers += gained;
+      game.happiness = clamp(game.happiness + 5);
+      addLog(`You promoted your account and gained ${gained} followers.`);
+      count.textContent = `Followers: ${game.followers}`;
+    });
   });
 
   wrap.appendChild(post);

--- a/activities/vacation.js
+++ b/activities/vacation.js
@@ -1,6 +1,5 @@
-import { game, addLog, saveGame } from '../state.js';
+import { game, addLog, applyAndSave } from '../state.js';
 import { clamp, rand } from '../utils.js';
-import { refreshOpenWindows } from '../windowManager.js';
 
 export function renderVacation(container) {
   const head = document.createElement('div');
@@ -14,17 +13,17 @@ export function renderVacation(container) {
   btn.addEventListener('click', () => {
     const cost = 500;
     if (game.money < cost) {
-      addLog('Vacation costs $500. Not enough money.');
-      refreshOpenWindows();
-      saveGame();
+      applyAndSave(() => {
+        addLog('Vacation costs $500. Not enough money.');
+      });
       return;
     }
-    game.money -= cost;
-    const gain = rand(8, 15);
-    game.happiness = clamp(game.happiness + gain);
-    addLog(`You went on a vacation. +${gain} Happiness.`);
-    refreshOpenWindows();
-    saveGame();
+    applyAndSave(() => {
+      game.money -= cost;
+      const gain = rand(8, 15);
+      game.happiness = clamp(game.happiness + gain);
+      addLog(`You went on a vacation. +${gain} Happiness.`);
+    });
   });
 
   container.appendChild(btn);

--- a/activities/willAndTestament.js
+++ b/activities/willAndTestament.js
@@ -1,5 +1,4 @@
-import { game, addLog, saveGame } from '../state.js';
-import { refreshOpenWindows } from '../windowManager.js';
+import { game, addLog, applyAndSave } from '../state.js';
 
 export function renderWillAndTestament(container) {
   const wrap = document.createElement('div');
@@ -8,41 +7,41 @@ export function renderWillAndTestament(container) {
     {
       label: 'Leave to partner',
       action: () => {
-        if (!game.relationships.length) {
-          addLog('You have no partner to leave your estate to.');
-        } else {
-          const partner = game.relationships[0].name;
-          game.inheritance = { [partner]: 1 };
-          addLog(`You updated your will: everything goes to ${partner}.`);
-        }
-        refreshOpenWindows();
-        saveGame();
+        applyAndSave(() => {
+          if (!game.relationships.length) {
+            addLog('You have no partner to leave your estate to.');
+          } else {
+            const partner = game.relationships[0].name;
+            game.inheritance = { [partner]: 1 };
+            addLog(`You updated your will: everything goes to ${partner}.`);
+          }
+        });
       }
     },
     {
       label: 'Divide among children',
       action: () => {
-        if (!game.children || game.children.length === 0) {
-          addLog('You have no children to inherit your estate.');
-        } else {
-          const share = 1 / game.children.length;
-          game.inheritance = {};
-          for (const child of game.children) {
-            game.inheritance[child.name] = share;
+        applyAndSave(() => {
+          if (!game.children || game.children.length === 0) {
+            addLog('You have no children to inherit your estate.');
+          } else {
+            const share = 1 / game.children.length;
+            game.inheritance = {};
+            for (const child of game.children) {
+              game.inheritance[child.name] = share;
+            }
+            addLog('You updated your will to divide your estate among your children.');
           }
-          addLog('You updated your will to divide your estate among your children.');
-        }
-        refreshOpenWindows();
-        saveGame();
+        });
       }
     },
     {
       label: 'Donate to charity',
       action: () => {
-        game.inheritance = { Charity: 1 };
-        addLog('You updated your will to donate your estate to charity.');
-        refreshOpenWindows();
-        saveGame();
+        applyAndSave(() => {
+          game.inheritance = { Charity: 1 };
+          addLog('You updated your will to donate your estate to charity.');
+        });
       }
     }
   ];

--- a/activities/zoo.js
+++ b/activities/zoo.js
@@ -1,6 +1,5 @@
-import { game, addLog, saveGame } from '../state.js';
+import { game, addLog, applyAndSave } from '../state.js';
 import { clamp } from '../utils.js';
-import { refreshOpenWindows } from '../windowManager.js';
 
 const EXHIBITS = [
   { name: 'Lions', cost: 25, stat: 'happiness', gain: 4 },
@@ -25,21 +24,21 @@ export function renderZoo(container) {
     btn.disabled = game.money < ex.cost;
     btn.addEventListener('click', () => {
       if (game.money < ex.cost) {
-        addLog('You cannot afford that ticket.');
-        refreshOpenWindows();
-        saveGame();
+        applyAndSave(() => {
+          addLog('You cannot afford that ticket.');
+        });
         return;
       }
-      game.money -= ex.cost;
-      if (ex.stat === 'happiness') {
-        game.happiness = clamp(game.happiness + ex.gain);
-      } else if (ex.stat === 'smarts') {
-        game.smarts = clamp(game.smarts + ex.gain);
-      }
-      const statName = ex.stat === 'smarts' ? 'Smarts' : 'Happiness';
-      addLog(`You visited the ${ex.name}. +${ex.gain} ${statName}.`);
-      refreshOpenWindows();
-      saveGame();
+      applyAndSave(() => {
+        game.money -= ex.cost;
+        if (ex.stat === 'happiness') {
+          game.happiness = clamp(game.happiness + ex.gain);
+        } else if (ex.stat === 'smarts') {
+          game.smarts = clamp(game.smarts + ex.gain);
+        }
+        const statName = ex.stat === 'smarts' ? 'Smarts' : 'Happiness';
+        addLog(`You visited the ${ex.name}. +${ex.gain} ${statName}.`);
+      });
     });
     list.appendChild(btn);
   }

--- a/activities/zooTrip.js
+++ b/activities/zooTrip.js
@@ -1,6 +1,5 @@
-import { game, addLog, saveGame } from '../state.js';
+import { game, addLog, applyAndSave } from '../state.js';
 import { clamp } from '../utils.js';
-import { refreshOpenWindows } from '../windowManager.js';
 
 const TRIPS = [
   { name: 'Local Zoo', cost: 40, mood: 5 },
@@ -45,17 +44,17 @@ export function renderZooTrip(container) {
     const people = Math.max(parseInt(count.value, 10) || 1, 1);
     const cost = trip.cost * people;
     if (game.money < cost) {
-      addLog(`Zoo trip costs $${cost}. Not enough money.`);
-      refreshOpenWindows();
-      saveGame();
+      applyAndSave(() => {
+        addLog(`Zoo trip costs $${cost}. Not enough money.`);
+      });
       return;
     }
-    game.money -= cost;
-    const mood = trip.mood * people;
-    game.happiness = clamp(game.happiness + mood);
-    addLog(`You visited the ${trip.name.toLowerCase()} with ${people} ${people === 1 ? 'person' : 'people'}. +${mood} Happiness.`);
-    refreshOpenWindows();
-    saveGame();
+    applyAndSave(() => {
+      game.money -= cost;
+      const mood = trip.mood * people;
+      game.happiness = clamp(game.happiness + mood);
+      addLog(`You visited the ${trip.name.toLowerCase()} with ${people} ${people === 1 ? 'person' : 'people'}. +${mood} Happiness.`);
+    });
   });
   wrap.appendChild(btn);
 

--- a/state.js
+++ b/state.js
@@ -48,6 +48,12 @@ export function saveGame() {
   localStorage.setItem('gameState', JSON.stringify(game));
 }
 
+export function applyAndSave(updater) {
+  updater();
+  refreshOpenWindows();
+  saveGame();
+}
+
 export function loadGame() {
   const data = localStorage.getItem('gameState');
   if (!data) return false;


### PR DESCRIPTION
## Summary
- add `applyAndSave` helper to run updates then refresh UI and persist state
- refactor `actions.js` and `activities` to remove repeated refresh/save calls

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8be00e32c832a920afc8fa6bac780