### PR TITLE
docs: add JSDoc for exported functions

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -43,6 +43,10 @@ function randomEvent() {
   }
 }
 
+/**
+ * Advances the game by one year and processes daily updates.
+ * @returns {void}
+ */
 export function ageUp() {
   if (!game.alive) {
     addLog('You are no longer alive. Start a new life.');
@@ -73,6 +77,10 @@ export function ageUp() {
   saveGame();
 }
 
+/**
+ * Studies to increase smarts, possibly affecting happiness.
+ * @returns {void}
+ */
 export function study() {
   if (!game.alive) return;
   if (game.inJail) {
@@ -87,6 +95,10 @@ export function study() {
   saveGame();
 }
 
+/**
+ * Works overtime to earn extra money at the cost of well-being.
+ * @returns {void}
+ */
 export function workExtra() {
   if (!game.job) {
     addLog('You need a job first.');
@@ -107,6 +119,10 @@ export function workExtra() {
   saveGame();
 }
 
+/**
+ * Visits the gym or works out in jail to improve stats.
+ * @returns {void}
+ */
 export function hitGym() {
   if (game.inJail) {
     game.health = clamp(game.health + rand(2, 5));
@@ -128,6 +144,10 @@ export function hitGym() {
   saveGame();
 }
 
+/**
+ * Visits the doctor for health recovery.
+ * @returns {void}
+ */
 export function seeDoctor() {
   if (game.inJail) {
     addLog('No access to a doctor here.');
@@ -153,6 +173,10 @@ export function seeDoctor() {
   saveGame();
 }
 
+/**
+ * Attempts a crime with varying risk and reward.
+ * @returns {void}
+ */
 export function crime() {
   if (game.inJail) {
     addLog('You are already in jail.');

--- a/state.js
+++ b/state.js
@@ -31,6 +31,11 @@ export const game = {
   log: []
 };
 
+/**
+ * Adds an entry to the game log and refreshes any open windows.
+ * @param {string} text - Message to record in the log.
+ * @returns {void}
+ */
 export function addLog(text) {
   const when = `${game.year} • age ${game.age}`;
   game.log.unshift({ when, text });
@@ -38,16 +43,29 @@ export function addLog(text) {
   refreshOpenWindows();
 }
 
+/**
+ * Ends the current life with a supplied reason.
+ * @param {string} reason - Cause of death to log.
+ * @returns {void}
+ */
 export function die(reason) {
   game.alive = false;
   addLog(reason);
   showEndScreen(game);
 }
 
+/**
+ * Saves the current game state to local storage.
+ * @returns {void}
+ */
 export function saveGame() {
   localStorage.setItem('gameState', JSON.stringify(game));
 }
 
+/**
+ * Loads the game state from local storage if available.
+ * @returns {boolean} True if a saved game was found and loaded.
+ */
 export function loadGame() {
   const data = localStorage.getItem('gameState');
   if (!data) return false;
@@ -56,6 +74,10 @@ export function loadGame() {
   return true;
 }
 
+/**
+ * Starts a new life, resetting the game state and prompting for basic info.
+ * @returns {void}
+ */
 export function newLife() {
   const now = new Date().getFullYear();
   hideEndScreen();

--- a/windowManager.js
+++ b/windowManager.js
@@ -242,10 +242,23 @@ function ensureWindow(id, title) {
   return win;
 }
 
+/**
+ * Registers a window and its render function.
+ * @param {string} id - Unique identifier for the window.
+ * @param {string} title - Title displayed on the window.
+ * @param {(content: HTMLElement, win: HTMLElement) => void} renderFn - Renders the window content.
+ * @returns {void}
+ */
 export function registerWindow(id, title, renderFn) {
   windowRegistry.set(id, { title, renderFn });
 }
 
+/**
+ * Initializes the window manager with desktop and template elements.
+ * @param {HTMLElement} desktopEl - Container element for windows.
+ * @param {HTMLTemplateElement} templateEl - Template used to clone new windows.
+ * @returns {void}
+ */
 export function initWindowManager(desktopEl, templateEl) {
   desktop = desktopEl;
   template = templateEl;
@@ -256,6 +269,13 @@ export function initWindowManager(desktopEl, templateEl) {
   });
 }
 
+/**
+ * Opens a window and renders its content.
+ * @param {string} id - Window identifier.
+ * @param {string} title - Window title.
+ * @param {(content: HTMLElement, win: HTMLElement) => void} renderFn - Rendering function.
+ * @returns {void}
+ */
 export function openWindow(id, title, renderFn) {
   registerWindow(id, title, renderFn);
   const win = ensureWindow(id, title);
@@ -268,6 +288,13 @@ export function openWindow(id, title, renderFn) {
   window.dispatchEvent(new CustomEvent('window-open', { detail: { id, win } }));
 }
 
+/**
+ * Toggles a window's visibility, opening or closing it as needed.
+ * @param {string} id - Window identifier.
+ * @param {string} title - Window title.
+ * @param {(content: HTMLElement, win: HTMLElement) => void} renderFn - Rendering function.
+ * @returns {void}
+ */
 export function toggleWindow(id, title, renderFn) {
   const win = desktop.querySelector(`.window[data-id="${id}"]`);
   if (win && !win.classList.contains('hidden')) {
@@ -277,6 +304,11 @@ export function toggleWindow(id, title, renderFn) {
   openWindow(id, title, renderFn);
 }
 
+/**
+ * Closes a window by its identifier.
+ * @param {string} id - Window identifier.
+ * @returns {void}
+ */
 export function closeWindow(id) {
   const win = desktop.querySelector(`.window[data-id="${id}"]`);
   if (!win) return;
@@ -289,6 +321,10 @@ export function closeWindow(id) {
   window.dispatchEvent(new CustomEvent('window-close', { detail: { id, win } }));
 }
 
+/**
+ * Restores any windows that were open in the previous session.
+ * @returns {void}
+ */
 export function restoreOpenWindows() {
   const stored = localStorage.getItem(OPEN_WINDOWS_KEY);
   if (!stored) return;
@@ -301,6 +337,10 @@ export function restoreOpenWindows() {
   });
 }
 
+/**
+ * Re-renders all currently open windows.
+ * @returns {void}
+ */
 export function refreshOpenWindows() {
   for (const [id, { renderFn: fn }] of windowRegistry.entries()) {
     const win = desktop.querySelector(`.window[data-id="${id}"]`);
@@ -311,6 +351,10 @@ export function refreshOpenWindows() {
   }
 }
 
+/**
+ * Closes all windows and clears the active state.
+ * @returns {void}
+ */
 export function closeAllWindows() {
   document.querySelectorAll('.window:not(.hidden)').forEach(win => {
     win.classList.add('hidden');


### PR DESCRIPTION
## Summary
- document exported window functions for easier API reference
- add JSDoc to game actions and state helpers

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/JustAnotherTestrepo/package.json')*
- `npm run docs` *(fails: ENOENT: no such file or directory, open '/workspace/JustAnotherTestrepo/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68b8bdfdd484832abaccf9ae14e44f6a