### PR TITLE
Refactor renderers to avoid innerHTML templates

### DIFF
--- a/endscreen.js
+++ b/endscreen.js
@@ -34,7 +34,7 @@ function generateStory(game) {
 }
 
 export function showEndScreen(game) {
-  screenEl.innerHTML = '';
+  screenEl.textContent = '';
   const title = document.createElement('h2');
   title.textContent = 'Life Story';
   screenEl.appendChild(title);
@@ -44,7 +44,11 @@ export function showEndScreen(game) {
   const list = document.createElement('ul');
   for (const item of game.log.slice().reverse()) {
     const li = document.createElement('li');
-    li.innerHTML = `<time>${item.when}</time> ${item.text}`;
+    const time = document.createElement('time');
+    time.textContent = item.when;
+    li.appendChild(time);
+    li.appendChild(document.createTextNode(' '));
+    li.appendChild(document.createTextNode(item.text));
     list.appendChild(li);
   }
   screenEl.appendChild(list);
@@ -59,6 +63,6 @@ export function showEndScreen(game) {
 
 export function hideEndScreen() {
   screenEl.classList.add('hidden');
-  screenEl.innerHTML = '';
+  screenEl.textContent = '';
 }
 

--- a/renderers/jobs.js
+++ b/renderers/jobs.js
@@ -10,7 +10,7 @@ export function renderJobs(container) {
     container.appendChild(head);
     return;
   }
-  head.innerHTML = `Pick a job. Smarter roles require higher Smarts.`;
+  head.textContent = 'Pick a job. Smarter roles require higher Smarts.';
   container.appendChild(head);
   const jobs = generateJobs();
   const wrap = document.createElement('div');
@@ -19,7 +19,21 @@ export function renderJobs(container) {
     const e = document.createElement('div');
     e.className = 'job';
     const ok = game.smarts >= j.reqSmarts;
-    e.innerHTML = `<div><strong>${j.title}</strong><div class="muted">Req Smarts: ${j.reqSmarts}</div></div><div><span class="badge">$${j.salary.toLocaleString()}/yr</span></div>`;
+    const left = document.createElement('div');
+    const strong = document.createElement('strong');
+    strong.textContent = j.title;
+    left.appendChild(strong);
+    const req = document.createElement('div');
+    req.className = 'muted';
+    req.textContent = `Req Smarts: ${j.reqSmarts}`;
+    left.appendChild(req);
+    const right = document.createElement('div');
+    const badge = document.createElement('span');
+    badge.className = 'badge';
+    badge.textContent = `$${j.salary.toLocaleString()}/yr`;
+    right.appendChild(badge);
+    e.appendChild(left);
+    e.appendChild(right);
     if (!ok) e.style.opacity = 0.6;
     e.title = ok ? 'Take job' : 'Your Smarts are too low for this role';
     e.addEventListener('click', () => {

--- a/renderers/stats.js
+++ b/renderers/stats.js
@@ -6,18 +6,58 @@ export function renderStats(container) {
     const pct = clamp(val);
     const div = document.createElement('div');
     div.className = 'kpi';
-    div.innerHTML = `<span class="label">${label}</span><div class="bar"><div class="fill" style="width:${pct}%"></div></div><span class="num">${pct}</span>`;
+    const labelSpan = document.createElement('span');
+    labelSpan.className = 'label';
+    labelSpan.textContent = label;
+    div.appendChild(labelSpan);
+    const bar = document.createElement('div');
+    bar.className = 'bar';
+    const fill = document.createElement('div');
+    fill.className = 'fill';
+    fill.style.width = `${pct}%`;
+    bar.appendChild(fill);
+    div.appendChild(bar);
+    const numSpan = document.createElement('span');
+    numSpan.className = 'num';
+    numSpan.textContent = String(pct);
+    div.appendChild(numSpan);
     return div;
   };
   const top = document.createElement('div');
   top.className = 'grid';
-  top.innerHTML = `
-        <div class="row"><strong>Year:</strong> <span>${game.year}</span></div>
-        <div class="row"><strong>Age:</strong> <span>${game.age}</span></div>
-        <div class="row"><strong>Money:</strong> <span>$${game.money.toLocaleString()}</span></div>
-        <div class="row"><strong>Status:</strong> <span>${game.alive ? (game.inJail ? 'In Jail' : 'Alive') : 'Deceased'}</span></div>
-        <div class="row"><strong>Job:</strong> <span>${game.job ? `${game.job.title} <span class='badge'>$${game.job.salary.toLocaleString()}</span>` : '—'}</span></div>
-        <div class="row"><strong>Illness:</strong> <span>${game.sick ? 'Sick' : '—'}</span></div>`;
+  const addRow = (label, value) => {
+    const row = document.createElement('div');
+    row.className = 'row';
+    const strong = document.createElement('strong');
+    strong.textContent = `${label}:`;
+    row.appendChild(strong);
+    row.appendChild(document.createTextNode(' '));
+    const span = document.createElement('span');
+    if (value instanceof Node) {
+      span.appendChild(value);
+    } else {
+      span.textContent = value;
+    }
+    row.appendChild(span);
+    top.appendChild(row);
+  };
+  addRow('Year', game.year);
+  addRow('Age', game.age);
+  addRow('Money', `$${game.money.toLocaleString()}`);
+  const status = game.alive ? (game.inJail ? 'In Jail' : 'Alive') : 'Deceased';
+  addRow('Status', status);
+  if (game.job) {
+    const jobSpan = document.createElement('span');
+    jobSpan.textContent = `${game.job.title} `;
+    const badge = document.createElement('span');
+    badge.className = 'badge';
+    badge.textContent = `$${game.job.salary.toLocaleString()}`;
+    jobSpan.appendChild(badge);
+    addRow('Job', jobSpan);
+  } else {
+    addRow('Job', '—');
+  }
+  addRow('Illness', game.sick ? 'Sick' : '—');
   container.appendChild(top);
   container.appendChild(makeKpi('Health', game.health));
   container.appendChild(makeKpi('Happiness', game.happiness));


### PR DESCRIPTION
## Summary
- Build stat KPIs and summary rows using DOM nodes instead of HTML templates
- Render job listings with `createElement` and `textContent` for safer user values
- Replace end screen list templating with explicit DOM creation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8bde9228c832a8e3a5f345bc5e37f