### PR TITLE
Replace prompts with in-game new life modal

### DIFF
--- a/endscreen.js
+++ b/endscreen.js
@@ -1,5 +1,6 @@
 import { StoryNet } from './storyNet.js';
-import { newLife } from './state.js';
+import { openWindow } from './windowManager.js';
+import { renderNewLife } from './renderers/newlife.js';
 
 const screenEl = document.getElementById('endscreen');
 const net = new StoryNet();
@@ -51,7 +52,7 @@ export function showEndScreen(game) {
   const restart = document.createElement('button');
   restart.textContent = 'Start new life';
   restart.addEventListener('click', () => {
-    newLife();
+    openWindow('newLife', 'New Life', renderNewLife);
   });
   screenEl.appendChild(restart);
   screenEl.classList.remove('hidden');

--- a/renderers/newlife.js
+++ b/renderers/newlife.js
@@ -3,29 +3,53 @@ import { openWindow, closeWindow } from '../windowManager.js';
 import { renderStats } from './stats.js';
 
 export function renderNewLife(container) {
-  const wrap = document.createElement('div');
-  wrap.className = 'new-life';
+  const form = document.createElement('form');
+  form.className = 'new-life';
 
   const msg = document.createElement('p');
-  msg.textContent = 'Start a new life? Your current progress will be lost.';
-  wrap.appendChild(msg);
+  msg.textContent = 'Start a new life. Your current progress will be lost.';
+  form.appendChild(msg);
 
-  const start = document.createElement('button');
-  start.textContent = 'Start New Life';
-  start.addEventListener('click', () => {
-    newLife();
-    openWindow('stats', 'Stats', renderStats);
-    closeWindow('newLife');
+  const genderLabel = document.createElement('label');
+  genderLabel.textContent = 'Gender:';
+  const genderSelect = document.createElement('select');
+  ['Male', 'Female'].forEach(g => {
+    const opt = document.createElement('option');
+    opt.value = g;
+    opt.textContent = g;
+    genderSelect.appendChild(opt);
   });
-  wrap.appendChild(start);
+  genderLabel.appendChild(genderSelect);
+  form.appendChild(genderLabel);
 
+  const nameLabel = document.createElement('label');
+  nameLabel.textContent = 'Name:';
+  const nameInput = document.createElement('input');
+  nameInput.type = 'text';
+  nameLabel.appendChild(nameInput);
+  form.appendChild(nameLabel);
+
+  const controls = document.createElement('div');
+  const start = document.createElement('button');
+  start.type = 'submit';
+  start.textContent = 'Start New Life';
+  controls.appendChild(start);
   const cancel = document.createElement('button');
+  cancel.type = 'button';
   cancel.textContent = 'Cancel';
   cancel.addEventListener('click', () => {
     closeWindow('newLife');
   });
-  wrap.appendChild(cancel);
+  controls.appendChild(cancel);
+  form.appendChild(controls);
 
-  container.appendChild(wrap);
+  form.addEventListener('submit', e => {
+    e.preventDefault();
+    newLife(genderSelect.value, nameInput.value);
+    openWindow('stats', 'Stats', renderStats);
+    closeWindow('newLife');
+  });
+
+  container.appendChild(form);
 }
 

--- a/script.js
+++ b/script.js
@@ -1,5 +1,5 @@
 import { initWindowManager, openWindow, toggleWindow, registerWindow, restoreOpenWindows, closeAllWindows } from './windowManager.js';
-import { newLife, loadGame } from './state.js';
+import { loadGame } from './state.js';
 import { renderStats } from './renderers/stats.js';
 import { renderActions } from './renderers/actions.js';
 import { renderLog } from './renderers/log.js';
@@ -123,16 +123,16 @@ function toggleWindowById(id) {
 }
 
 Object.keys(windows).forEach(id => {
+  if (id === 'newLife') return;
   document.querySelectorAll(`[data-toggle="${id}"]`).forEach(btn => {
     btn.addEventListener('click', () => toggleWindowById(id));
   });
 });
 
-document.getElementById('newLife').addEventListener('click', () => {
-  if (confirm('Start a new life? Your current progress will be lost.')) {
-    newLife();
-    openStats();
-  }
+document.querySelectorAll(`[data-toggle="newLife"]`).forEach(btn => {
+  btn.addEventListener('click', () => {
+    openWindow('newLife', 'New Life', renderNewLife);
+  });
 });
 document.getElementById('closeAll').addEventListener('click', () => {
   closeAllWindows();
@@ -144,7 +144,7 @@ themeToggle.addEventListener('click', () => {
 });
 
 if (!loadGame()) {
-  newLife();
+  openWindow('newLife', 'New Life', renderNewLife);
 }
 openWindowById('stats');
 openWindowById('actions');

--- a/state.js
+++ b/state.js
@@ -56,20 +56,19 @@ export function loadGame() {
   return true;
 }
 
-export function newLife() {
+export function newLife(genderInput, nameInput) {
   const now = new Date().getFullYear();
   hideEndScreen();
   localStorage.removeItem('gameState');
-  let gender = prompt('Enter gender (Male/Female):')?.trim();
+  let gender = genderInput?.trim();
   if (gender) {
     const lower = gender.toLowerCase();
     if (lower === 'male') gender = 'Male';
     else if (lower === 'female') gender = 'Female';
-  }
-  if (!gender) {
+  } else {
     gender = rand(0, 1) === 0 ? 'Male' : 'Female';
   }
-  let name = prompt('Enter name:')?.trim();
+  let name = nameInput?.trim();
   if (!name) {
     const firstName = faker.person.firstName(
       gender === 'Male' ? 'male' : gender === 'Female' ? 'female' : undefined


### PR DESCRIPTION
## Summary
- Replace native confirm prompt with window-manager modal for starting a new life.
- Collect gender and name via a new in-game window and feed them into `newLife`.
- Start new lives from the end screen or toolbar without browser popups.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8bdd3d2d8832a9263dad59003deda