### PR TITLE
feat: add house icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,9 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Tiny Life — draggable window BitLife-like</title>
-  
+
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
   <link rel="stylesheet" href="variables.css">
   <link rel="stylesheet" href="base.css">
   <link rel="stylesheet" href="components.css">

--- a/realestate.js
+++ b/realestate.js
@@ -15,11 +15,89 @@ let faker = fallbackFaker;
 
 // house categories loaded from external data
 let houseCategories = [];
+const iconMappings = [
+  {
+    keywords: ['trailer', 'manufactured'],
+    icon: { type: 'fa', icon: 'fa-person-shelter' }
+  },
+  {
+    keywords: [
+      'tiny',
+      'cottage',
+      'cabin',
+      'bungalow',
+      'mid century',
+      'craftsman',
+      'colonial'
+    ],
+    icon: { type: 'mi', icon: 'cottage' }
+  },
+  {
+    keywords: [
+      'condo',
+      'townhome',
+      'loft',
+      'penthouse',
+      'skyscraper',
+      'suite',
+      'apartment',
+      'duplex'
+    ],
+    icon: { type: 'fa', icon: 'fa-building' }
+  },
+  {
+    keywords: ['houseboat', 'floating', 'underwater'],
+    icon: { type: 'mi', icon: 'houseboat' }
+  },
+  {
+    keywords: ['farm', 'ranch'],
+    icon: { type: 'fa', icon: 'fa-tractor' }
+  },
+  {
+    keywords: ['villa'],
+    icon: { type: 'mi', icon: 'villa' }
+  },
+  {
+    keywords: ['mansion', 'estate'],
+    icon: { type: 'mi', icon: 'domain' }
+  },
+  {
+    keywords: ['chateau', 'castle'],
+    icon: { type: 'fa', icon: 'fa-fort-awesome' }
+  },
+  {
+    keywords: ['beach', 'oceanfront', 'river', 'lake', 'coastal', 'lakeside'],
+    icon: { type: 'fa', icon: 'fa-water' }
+  },
+  {
+    keywords: ['treehouse'],
+    icon: { type: 'fa', icon: 'fa-tree-city' }
+  },
+  {
+    keywords: ['futuristic', 'space', 'lunar', 'galactic'],
+    icon: { type: 'fa', icon: 'fa-landmark' }
+  }
+];
+
+const defaultIcon = { type: 'fa', icon: 'fa-house' };
+
+function pickIcon(name) {
+  const lower = name.toLowerCase();
+  for (const mapping of iconMappings) {
+    if (mapping.keywords.some(k => lower.includes(k))) {
+      return mapping.icon;
+    }
+  }
+  return defaultIcon;
+}
 
 async function loadHouseCategories() {
   if (houseCategories.length) return houseCategories;
   const res = await fetch('./activities/data/houseCategories.json');
   houseCategories = await res.json();
+  houseCategories.forEach(c => {
+    c.icon = pickIcon(c.type);
+  });
   return houseCategories;
 }
 
@@ -80,7 +158,8 @@ export async function initBrokers() {
       listings.push({
         id: `${i}-${j}-${Date.now()}`,
         name: category.type,
-        value
+        value,
+        icon: category.icon
       });
     }
     const name = names.splice(rand(0, names.length - 1), 1)[0];
@@ -106,7 +185,8 @@ export function buyProperty(broker, listing) {
     condition: 100,
     rented: false,
     rent: 0,
-    tenant: null
+    tenant: null,
+    icon: listing.icon
   };
   game.properties.push(prop);
   broker.listings = broker.listings.filter(l => l !== listing);

--- a/renderers/realestate.js
+++ b/renderers/realestate.js
@@ -21,7 +21,16 @@ export function renderRealEstate(container) {
     } else {
       listings.forEach(l => {
         const row = document.createElement('div');
-        row.textContent = `${l.name} - $${l.value.toLocaleString()}`;
+        const icon = document.createElement(l.icon.type === 'fa' ? 'i' : 'span');
+        if (l.icon.type === 'fa') {
+          icon.className = `fa-solid ${l.icon.icon}`;
+        } else {
+          icon.className = 'material-icons';
+          icon.textContent = l.icon.icon;
+        }
+        icon.style.marginRight = '4px';
+        row.appendChild(icon);
+        row.appendChild(document.createTextNode(` ${l.name} - $${l.value.toLocaleString()}`));
         const btn = document.createElement('button');
         btn.textContent = 'Buy';
         btn.disabled = game.money < l.value;
@@ -50,7 +59,18 @@ export function renderRealEstate(container) {
       const row = document.createElement('div');
       row.style.marginTop = '4px';
       const info = document.createElement('div');
-      info.textContent = `${p.name} - Val $${p.value.toLocaleString()} - Cond ${p.condition}%`;
+      const icon = document.createElement(p.icon.type === 'fa' ? 'i' : 'span');
+      if (p.icon.type === 'fa') {
+        icon.className = `fa-solid ${p.icon.icon}`;
+      } else {
+        icon.className = 'material-icons';
+        icon.textContent = p.icon.icon;
+      }
+      icon.style.marginRight = '4px';
+      info.appendChild(icon);
+      info.appendChild(
+        document.createTextNode(` ${p.name} - Val $${p.value.toLocaleString()} - Cond ${p.condition}%`)
+      );
       row.appendChild(info);
       const rentDiv = document.createElement('div');
       if (!p.rented) {


### PR DESCRIPTION
## Summary
- add Font Awesome and Material Icons stylesheets
- assign icon metadata to house categories and listings
- render icons for broker listings and owned properties
- map icons to house categories using keywords for consistent visuals

## Testing
- `npm test` *(fails: Cannot find module '/workspace/JustAnotherTestrepo/node_modules/jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_68b8c1df3ff8832aa76170df4d332d03