### PR TITLE
Add button to quit existing job

### DIFF
--- a/renderers/jobs.js
+++ b/renderers/jobs.js
@@ -12,6 +12,18 @@ export function renderJobs(container) {
   }
   head.textContent = 'Pick a job. Smarter roles require higher Smarts.';
   container.appendChild(head);
+  if (game.job) {
+    const quit = document.createElement('button');
+    quit.className = 'btn';
+    quit.textContent = 'Quit Job';
+    quit.addEventListener('click', () => {
+      game.job = null;
+      addLog('You quit your job.');
+      saveGame();
+      refreshOpenWindows();
+    });
+    container.appendChild(quit);
+  }
   const jobs = generateJobs();
   const wrap = document.createElement('div');
   wrap.className = 'jobs';


### PR DESCRIPTION
## Summary
- Show a **Quit Job** button when the player already has a job
- Clicking the button removes the job, logs the action, saves the game, and refreshes windows

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68b8c47ac410832a804ab7c1eee1310c