### PR TITLE
refactor: async faker import with fallback in love activity

### DIFF
--- a/activities/love.js
+++ b/activities/love.js
@@ -1,6 +1,17 @@
 import { game, addLog, applyAndSave } from '../state.js';
 import { rand, clamp } from '../utils.js';
-import { faker } from 'https://cdn.jsdelivr.net/npm/@faker-js/faker@8.3.1/+esm';
+import { faker as fallbackFaker } from '../nameGenerator.js';
+
+let faker = fallbackFaker;
+
+(async () => {
+  try {
+    const mod = await import('https://cdn.jsdelivr.net/npm/@faker-js/faker@8.3.1/+esm');
+    faker = mod.faker;
+  } catch (err) {
+    console.warn('Faker CDN import failed, using internal generator', err);
+  }
+})();
 
 export function renderLove(container) {
   const wrap = document.createElement('div');


### PR DESCRIPTION
## Summary
- replace direct CDN import in love activity with dynamic import and fallback
- generate partner names via resolved faker instance

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8c48d7b58832ab06f6aab1fd52f3e