### PR TITLE
Add settings window with save/load and theme controls

### DIFF
--- a/partials/dock.html
+++ b/partials/dock.html
@@ -7,6 +7,7 @@
   <button data-toggle="log" role="button" aria-label="Open Log window">Log</button>
   <button data-toggle="jobs" role="button" aria-label="Open Job Hunt window">Job Hunt</button>
   <button data-toggle="realestate" role="button" aria-label="Open Real Estate window">Real Estate</button>
+  <button data-toggle="settings" role="button" aria-label="Open Settings window">Settings</button>
   <button data-toggle="help" role="button" aria-label="Open Help window">Help</button>
   <button data-toggle="newLife" role="button" aria-label="Start a new life">New Life</button>
   <button id="closeAll" role="button" aria-label="Close all windows">Close All</button>

--- a/renderers/settings.js
+++ b/renderers/settings.js
@@ -1,0 +1,28 @@
+import { saveGame, loadGame, newLife } from '../state.js';
+import { setTheme } from '../script.js';
+
+export function renderSettings(container) {
+  const wrap = document.createElement('div');
+  wrap.className = 'settings';
+
+  const mk = (text, fn) => {
+    const b = document.createElement('button');
+    b.className = 'btn';
+    b.textContent = text;
+    b.addEventListener('click', fn);
+    return b;
+  };
+
+  wrap.appendChild(mk('Save Game', saveGame));
+  wrap.appendChild(mk('Load Game', loadGame));
+  wrap.appendChild(mk('Start New Life', () => newLife()));
+  wrap.appendChild(
+    mk('Toggle Theme', () => {
+      const current = document.body.classList.contains('dark') ? 'light' : 'dark';
+      setTheme(current);
+    })
+  );
+
+  container.appendChild(wrap);
+}
+

--- a/script.js
+++ b/script.js
@@ -9,6 +9,7 @@ import { renderActivities } from './renderers/activities.js';
 import { renderRealEstate } from './renderers/realestate.js';
 import { renderHelp } from './renderers/help.js';
 import { renderNewLife } from './renderers/newlife.js';
+import { renderSettings } from './renderers/settings.js';
 
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
@@ -79,7 +80,7 @@ if (dock) {
   });
 }
 
-function setTheme(theme) {
+export function setTheme(theme) {
   const isDark = theme === 'dark';
   document.body.classList.toggle('dark', isDark);
   themeToggle.textContent = isDark ? '☀️' : '🌙';
@@ -119,6 +120,7 @@ registerWindow('jobs', 'Jobs', renderJobs);
 registerWindow('character', 'Character', renderCharacter);
 registerWindow('activities', 'Activities', renderActivities);
 registerWindow('realestate', 'Real Estate', renderRealEstate);
+registerWindow('settings', 'Settings', renderSettings);
 registerWindow('help', 'Help', renderHelp);
 registerWindow('newLife', 'New Life', renderNewLife);
 
@@ -145,7 +147,13 @@ Object.keys(windows).forEach(id => {
   document.querySelectorAll(`[data-toggle="${id}"]`).forEach(btn => {
     btn.addEventListener('click', () => toggleWindow(id, title, renderFn));
   });
-}
+});
+
+document.querySelectorAll(`[data-toggle="settings"]`).forEach(btn => {
+  btn.addEventListener('click', () => {
+    toggleWindow('settings', 'Settings', renderSettings);
+  });
+});
 
 document.querySelectorAll(`[data-toggle="newLife"]`).forEach(btn => {
   btn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- Add Settings window with buttons for saving, loading, starting a new life, and toggling theme
- Export `setTheme` and register new Settings window
- Add Settings button to dock

## Testing
- `npm test` *(fails: Cannot find module '/workspace/JustAnotherTestrepo/node_modules/jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_68b8c4748514832a8e73a4831a661920