### PR TITLE
Add meditation action to raise happiness and smarts

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -95,6 +95,21 @@ export function study() {
 }
 
 /**
+ * Meditates to improve happiness and boost smarts slightly.
+ * @returns {void}
+ */
+export function meditate() {
+  if (!game.alive) return;
+  applyAndSave(() => {
+    const happy = rand(2, 5);
+    const smart = rand(1, 2);
+    game.happiness = clamp(game.happiness + happy);
+    game.smarts = clamp(game.smarts + smart);
+    addLog(`You meditated. +${happy} Happiness, +${smart} Smarts.`);
+  });
+}
+
+/**
  * Works overtime to earn extra money at the cost of well-being.
  * @returns {void}
  */

--- a/renderers/actions.js
+++ b/renderers/actions.js
@@ -1,5 +1,5 @@
 import { game } from '../state.js';
-import { ageUp, study, hitGym, workExtra, seeDoctor, crime } from '../actions.js';
+import { ageUp, study, meditate, hitGym, workExtra, seeDoctor, crime } from '../actions.js';
 import { toggleWindow } from '../windowManager.js';
 import { renderJobs } from './jobs.js';
 
@@ -17,6 +17,7 @@ export function renderActions(container) {
   const dead = !game.alive;
   g.appendChild(mk('👉 Age Up One Year', ageUp, dead));
   g.appendChild(mk('📚 Study (+Smarts)', study, dead));
+  g.appendChild(mk('🧘 Meditate (+Happiness/Smarts)', meditate, dead));
   g.appendChild(mk('🏋️ Gym (+Health/Happiness)', hitGym, dead));
   g.appendChild(mk('💼 Job Hunt (open window)', () => toggleWindow('jobs', 'Jobs', renderJobs), dead));
   g.appendChild(mk('💵 Work Overtime (+$$)', workExtra, dead || !game.job || game.inJail));


### PR DESCRIPTION
## Summary
- add meditate() action that increases happiness and slightly boosts smarts
- expose meditation through new 🧘 button in actions panel

## Testing
- `npm test` *(fails: Cannot find module 'jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_68b8c47e751c832aa96b8cbd770284b0