### PR TITLE
Add property tax deduction during real estate ticks

### DIFF
--- a/realestate.js
+++ b/realestate.js
@@ -248,6 +248,9 @@ export function tickRealEstate() {
   for (const prop of game.properties) {
     const factor = rand(95, 110) / 100;
     prop.value = Math.round(prop.value * factor);
+    const tax = Math.round(prop.value * 0.01);
+    game.money -= tax;
+    addLog(`Paid $${tax.toLocaleString()} in property tax for ${prop.name}.`);
     if (prop.rented) {
       game.money += prop.rent;
       prop.condition = clamp(prop.condition - rand(1, 3), 0, 100);


### PR DESCRIPTION
## Summary
- Deduct 1% property tax from cash every tick and log the payment

## Testing
- `npm test` *(fails: Cannot find module 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_68b8c4855f74832a800ea877f2ec3db0