### PR TITLE
Add log categories and filtering

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -9,32 +9,32 @@ function paySalary() {
     const monthly = game.job.salary / 12;
     const earned = Math.round(monthly * rand(10, 12));
     game.money += earned;
-    addLog(`You worked as a ${game.job.title} and earned $${earned.toLocaleString()}.`);
+    addLog(`You worked as a ${game.job.title} and earned $${earned.toLocaleString()}.`, 'job');
   }
 }
 
 function randomEvent() {
   if (game.age === 5) {
-    addLog('You learned to read and write. (+Smarts)');
+    addLog('You learned to read and write. (+Smarts)', 'education');
     game.smarts = clamp(game.smarts + rand(2, 5));
   }
   if (game.age === 12) {
-    addLog('You discovered video games. (+Happiness, -Looks?)');
+    addLog('You discovered video games. (+Happiness, -Looks?)', 'hobby');
     game.happiness = clamp(game.happiness + 4);
     game.looks = clamp(game.looks - 1);
   }
   if (game.age === 16) {
-    addLog('You can start looking for a part-time job.');
+    addLog('You can start looking for a part-time job.', 'job');
   }
   if (game.age === 18) {
-    addLog('You finished school. Time to work or study!');
+    addLog('You finished school. Time to work or study!', 'education');
   }
   if (!game.sick && rand(1, 100) <= 8) {
     game.sick = true;
-    addLog('You caught a nasty flu. (See Doctor)');
+    addLog('You caught a nasty flu. (See Doctor)', 'health');
   }
   if (game.age > 50 && rand(1, 100) <= game.age - 45) {
-    addLog('Aches and pains are catching up with you. (-Health)');
+    addLog('Aches and pains are catching up with you. (-Health)', 'health');
     game.health = clamp(game.health - rand(2, 6));
   }
   if (rand(1, 1000) === 1) {
@@ -48,7 +48,7 @@ function randomEvent() {
  */
 export function ageUp() {
   if (!game.alive) {
-    addLog('You are no longer alive. Start a new life.');
+    addLog('You are no longer alive. Start a new life.', 'life');
     saveGame();
     return;
   }
@@ -65,7 +65,7 @@ export function ageUp() {
     tickRealEstate();
     if (game.age >= game.maxAge) {
       game.alive = false;
-      addLog('You died of old age.');
+      addLog('You died of old age.', 'life');
     }
     if (game.health <= 0 && game.alive) {
       game.alive = false;
@@ -84,13 +84,13 @@ export function study() {
   if (!game.alive) return;
   applyAndSave(() => {
     if (game.inJail) {
-      addLog('You studied in jail. (+Smarts)');
+      addLog('You studied in jail. (+Smarts)', 'education');
     }
     const gain = rand(2, 4);
     const mood = rand(-1, 1);
     game.smarts = clamp(game.smarts + gain);
     game.happiness = clamp(game.happiness + mood);
-    addLog(`You studied hard. +${gain} Smarts${mood < 0 ? ` • ${mood} Happiness` : ''}.`);
+    addLog(`You studied hard. +${gain} Smarts${mood < 0 ? ` • ${mood} Happiness` : ''}.`, 'education');
   });
 }
 
@@ -100,12 +100,12 @@ export function study() {
  */
 export function workExtra() {
   if (!game.job) {
-    addLog('You need a job first.');
+    addLog('You need a job first.', 'job');
     saveGame();
     return;
   }
   if (game.inJail) {
-    addLog('You cannot work extra while in jail.');
+    addLog('You cannot work extra while in jail.', 'job');
     saveGame();
     return;
   }
@@ -114,7 +114,7 @@ export function workExtra() {
     game.money += bonus;
     game.happiness = clamp(game.happiness - rand(0, 2));
     game.health = clamp(game.health - rand(0, 2));
-    addLog(`You took overtime. Earned $${bonus.toLocaleString()}. (-Small Health/Happiness)`);
+    addLog(`You took overtime. Earned $${bonus.toLocaleString()}. (-Small Health/Happiness)`, 'job');
   });
 }
 
@@ -127,13 +127,13 @@ export function hitGym() {
     applyAndSave(() => {
       game.health = clamp(game.health + rand(2, 5));
       game.happiness = clamp(game.happiness + rand(1, 3));
-      addLog('You worked out in the yard. (+Health, +Happiness)');
+      addLog('You worked out in the yard. (+Health, +Happiness)', 'health');
     });
     return;
   }
   const cost = 20;
   if (game.money < cost) {
-    addLog('Not enough money for the gym ($20).');
+    addLog('Not enough money for the gym ($20).', 'health');
     saveGame();
     return;
   }
@@ -141,7 +141,7 @@ export function hitGym() {
     game.money -= cost;
     game.health = clamp(game.health + rand(2, 5));
     game.happiness = clamp(game.happiness + rand(1, 3));
-    addLog('You hit the gym. (+Health, +Happiness)');
+    addLog('You hit the gym. (+Health, +Happiness)', 'health');
   });
 }
 
@@ -151,13 +151,13 @@ export function hitGym() {
  */
 export function seeDoctor() {
   if (game.inJail) {
-    addLog('No access to a doctor here.');
+    addLog('No access to a doctor here.', 'health');
     saveGame();
     return;
   }
   const cost = game.sick ? 120 : 60;
   if (game.money < cost) {
-    addLog(`Doctor visit costs $${cost}. Not enough money.`);
+    addLog(`Doctor visit costs $${cost}. Not enough money.`, 'health');
     saveGame();
     return;
   }
@@ -166,10 +166,10 @@ export function seeDoctor() {
     if (game.sick) {
       game.sick = false;
       game.health = clamp(game.health + rand(6, 12));
-      addLog('The doctor treated your illness. (+Health)');
+      addLog('The doctor treated your illness. (+Health)', 'health');
     } else {
       game.health = clamp(game.health + rand(2, 6));
-      addLog('Routine check-up made you feel better. (+Health)');
+      addLog('Routine check-up made you feel better. (+Health)', 'health');
     }
   });
 }
@@ -180,7 +180,7 @@ export function seeDoctor() {
  */
 export function crime() {
   if (game.inJail) {
-    addLog('You are already in jail.');
+    addLog('You are already in jail.', 'crime');
     saveGame();
     return;
   }
@@ -197,16 +197,16 @@ export function crime() {
       const amount = rand(c.reward[0], c.reward[1]);
       game.money += amount;
       game.happiness = clamp(game.happiness + rand(0, 2));
-      addLog(`Crime succeeded: ${c.name}. You gained $${amount.toLocaleString()}.`);
+      addLog(`Crime succeeded: ${c.name}. You gained $${amount.toLocaleString()}.`, 'crime');
     } else {
       if (rand(1, 100) <= 75) {
         game.inJail = true;
         game.jailYears = rand(1, 4);
-        addLog(`Busted doing ${c.name}. You were jailed for ${game.jailYears} year(s).`);
+        addLog(`Busted doing ${c.name}. You were jailed for ${game.jailYears} year(s).`, 'crime');
       } else {
         const dmg = rand(4, 15);
         game.health = clamp(game.health - dmg);
-        addLog(`Crime failed: ${c.name}. You were injured (-${dmg} Health).`);
+        addLog(`Crime failed: ${c.name}. You were injured (-${dmg} Health).`, 'crime');
         if (game.health <= 0) {
           die('You died from your injuries.');
         }

--- a/activities/accessories.js
+++ b/activities/accessories.js
@@ -25,7 +25,7 @@ export function renderAccessories(container) {
     btn.addEventListener('click', () => {
       if (game.money < item.cost) {
         applyAndSave(() => {
-          addLog('You cannot afford that item.');
+          addLog('You cannot afford that item.', 'shopping');
         });
         return;
       }
@@ -33,7 +33,7 @@ export function renderAccessories(container) {
         game.money -= item.cost;
         game.looks = clamp(game.looks + item.looks);
         game.accessories.push(item.name);
-        addLog(`You bought ${item.name}. (+Looks)`);
+        addLog(`You bought ${item.name}. (+Looks)`, 'shopping');
       });
     });
     list.appendChild(btn);

--- a/activities/adoption.js
+++ b/activities/adoption.js
@@ -28,7 +28,7 @@ export function renderAdoption(container) {
         const child = { name, age: opt.age, happiness: opt.happiness };
         if (!game.children) game.children = [];
         game.children.push(child);
-        addLog(`You adopted ${name}.`);
+        addLog(`You adopted ${name}.`, 'family');
       });
     });
     wrap.appendChild(btn);

--- a/activities/blackMarket.js
+++ b/activities/blackMarket.js
@@ -20,7 +20,7 @@ export function renderBlackMarket(container) {
     const cost = 100;
     if (game.money < cost) {
       applyAndSave(() => {
-        addLog('Contraband costs $100. Not enough money.');
+        addLog('Contraband costs $100. Not enough money.', 'crime');
       });
       return;
     }
@@ -31,18 +31,18 @@ export function renderBlackMarket(container) {
         if (rand(1, 100) <= 50) {
           const fine = 200;
           game.money = Math.max(0, game.money - fine);
-          addLog(`You were caught with contraband and fined $${fine}.`);
+          addLog(`You were caught with contraband and fined $${fine}.`, 'crime');
           result.textContent = `Penalty: Fined $${fine}`;
         } else {
           game.inJail = true;
           game.jailYears = rand(1, 3);
-          addLog(`You were jailed for contraband for ${game.jailYears} year(s).`);
+          addLog(`You were jailed for contraband for ${game.jailYears} year(s).`, 'crime');
           result.textContent = `Penalty: Jailed for ${game.jailYears} year(s)`;
         }
       } else {
         const gain = rand(3, 6);
         game.happiness = clamp(game.happiness + gain);
-        addLog(`Contraband acquired. +${gain} Happiness.`);
+        addLog(`Contraband acquired. +${gain} Happiness.`, 'crime');
         result.textContent = `Success: +${gain} Happiness`;
       }
     });

--- a/activities/casino.js
+++ b/activities/casino.js
@@ -16,7 +16,7 @@ export function renderCasino(container) {
     const bet = 10;
     if (game.money < bet) {
       applyAndSave(() => {
-        addLog('Not enough money to gamble.');
+        addLog('Not enough money to gamble.', 'gambling');
       });
       return;
     }
@@ -32,11 +32,11 @@ export function renderCasino(container) {
       if (win > 0) {
         game.money += win;
         game.happiness = clamp(game.happiness + 4);
-        addLog(`Slots win! You earned $${win}.`);
+        addLog(`Slots win! You earned $${win}.`, 'gambling');
         result.textContent = `Result: ${reels.join(' ')} - Won $${win}`;
       } else {
         game.happiness = clamp(game.happiness - 2);
-        addLog('Slots loss. Better luck next time.');
+        addLog('Slots loss. Better luck next time.', 'gambling');
         result.textContent = `Result: ${reels.join(' ')} - Loss`;
       }
     });

--- a/activities/commune.js
+++ b/activities/commune.js
@@ -8,7 +8,7 @@ const EVENTS = [
     run() {
       const gain = rand(5, 12);
       game.happiness = clamp(game.happiness + gain);
-      addLog(`You shared a communal meal. +${gain} Happiness.`);
+      addLog(`You shared a communal meal. +${gain} Happiness.`, 'community');
     }
   },
   {
@@ -21,7 +21,7 @@ const EVENTS = [
       game.happiness = clamp(game.happiness - happinessLoss);
       let msg = `You helped with garden chores. +${healthGain} Health`;
       if (happinessLoss) msg += `, -${happinessLoss} Happiness`;
-      addLog(msg + '.');
+      addLog(msg + '.', 'community');
     }
   },
   {
@@ -30,7 +30,7 @@ const EVENTS = [
     run() {
       const gain = rand(4, 8);
       game.happiness = clamp(game.happiness + gain);
-      addLog(`You meditated with the group. +${gain} Happiness.`);
+      addLog(`You meditated with the group. +${gain} Happiness.`, 'community');
     }
   }
 ];
@@ -48,7 +48,7 @@ export function renderCommune(container) {
     btn.addEventListener('click', () => {
       if (ev.cost && game.money < ev.cost) {
         applyAndSave(() => {
-          addLog(`${ev.name} costs $${ev.cost}. Not enough money.`);
+          addLog(`${ev.name} costs $${ev.cost}. Not enough money.`, 'community');
         });
         return;
       }

--- a/activities/doctor.js
+++ b/activities/doctor.js
@@ -19,14 +19,14 @@ export function renderDoctor(container) {
       const cost = 60;
       if (game.money < cost) {
         applyAndSave(() => {
-          addLog(`Doctor visit costs $${cost}. Not enough money.`);
+          addLog(`Doctor visit costs $${cost}. Not enough money.`, 'health');
         });
         return;
       }
       applyAndSave(() => {
         game.money -= cost;
         game.health = clamp(game.health + rand(2, 6));
-        addLog('Routine check-up made you feel better. (+Health)');
+        addLog('Routine check-up made you feel better. (+Health)', 'health');
       });
     })
   );
@@ -38,7 +38,7 @@ export function renderDoctor(container) {
         const cost = 120;
         if (game.money < cost) {
           applyAndSave(() => {
-            addLog(`Doctor visit costs $${cost}. Not enough money.`);
+            addLog(`Doctor visit costs $${cost}. Not enough money.`, 'health');
           });
           return;
         }
@@ -46,7 +46,7 @@ export function renderDoctor(container) {
           game.money -= cost;
           game.sick = false;
           game.health = clamp(game.health + rand(6, 12));
-          addLog('The doctor treated your illness. (+Health)');
+          addLog('The doctor treated your illness. (+Health)', 'health');
         });
       },
       !game.sick

--- a/activities/emigrate.js
+++ b/activities/emigrate.js
@@ -15,7 +15,7 @@ export function renderEmigrate(container) {
     const cost = 2000;
     if (game.money < cost) {
       applyAndSave(() => {
-        addLog('Emigration costs $2,000. Not enough money.');
+        addLog('Emigration costs $2,000. Not enough money.', 'travel');
       });
       return;
     }
@@ -34,7 +34,7 @@ export function renderEmigrate(container) {
       let logMsg = `You emigrated from ${oldCity}, ${oldCountry} to ${newCity}, ${newCountry}. +${happinessGain} Happiness`;
       if (healthLoss > 0) logMsg += `, -${healthLoss} Health`;
       logMsg += '.';
-      addLog(logMsg);
+      addLog(logMsg, 'travel');
     });
   });
 

--- a/activities/fertility.js
+++ b/activities/fertility.js
@@ -26,9 +26,9 @@ export function renderFertility(container) {
           const child = { name, age: 0, happiness: 90 };
           if (!game.children) game.children = [];
           game.children.push(child);
-          addLog(`Fertility treatment succeeded! You welcomed ${name}.`);
+          addLog(`Fertility treatment succeeded! You welcomed ${name}.`, 'family');
         } else {
-          addLog('Fertility treatment failed.');
+          addLog('Fertility treatment failed.', 'family');
         }
       });
     });

--- a/activities/gamble.js
+++ b/activities/gamble.js
@@ -25,7 +25,7 @@ export function renderGamble(container) {
     if (bet <= 0) return;
     if (game.money < bet) {
       applyAndSave(() => {
-        addLog('Not enough money to bet.');
+        addLog('Not enough money to bet.', 'gambling');
       });
       return;
     }
@@ -34,10 +34,10 @@ export function renderGamble(container) {
       if (rand(0, 1) === 1) {
         const payout = bet * 2;
         game.money += payout;
-        addLog(`You won $${payout}.`);
+        addLog(`You won $${payout}.`, 'gambling');
         result.textContent = `Result: Won $${payout}`;
       } else {
-        addLog(`You lost $${bet}.`);
+        addLog(`You lost $${bet}.`, 'gambling');
         result.textContent = 'Result: Loss';
       }
     });

--- a/activities/horseRacing.js
+++ b/activities/horseRacing.js
@@ -43,7 +43,7 @@ export function renderHorseRacing(container) {
     const bet = Math.max(1, parseInt(betInput.value, 10) || 0);
     if (game.money < bet) {
       applyAndSave(() => {
-        addLog('Not enough money to bet on horse racing.');
+        addLog('Not enough money to bet on horse racing.', 'gambling');
       });
       return;
     }
@@ -63,11 +63,11 @@ export function renderHorseRacing(container) {
         const payout = bet * choice.odds;
         game.money += payout;
         game.happiness = clamp(game.happiness + 4);
-        addLog(`${choice.name} won! You earned $${payout}.`);
+        addLog(`${choice.name} won! You earned $${payout}.`, 'gambling');
         result.textContent = `Winner: ${winner.name} — You won $${payout}`;
       } else {
         game.happiness = clamp(game.happiness - 2);
-        addLog(`${choice.name} lost the race.`);
+        addLog(`${choice.name} lost the race.`, 'gambling');
         result.textContent = `Winner: ${winner.name} — You lost $${bet}`;
       }
     });

--- a/activities/identity.js
+++ b/activities/identity.js
@@ -16,7 +16,7 @@ export function renderIdentity(container) {
   theftBtn.addEventListener('click', () => {
     if (game.inJail) {
       applyAndSave(() => {
-        addLog('You cannot attempt this in jail.');
+        addLog('You cannot attempt this in jail.', 'crime');
       });
       return;
     }
@@ -26,17 +26,17 @@ export function renderIdentity(container) {
         const amount = rand(1000, 8000);
         game.money += amount;
         game.happiness = clamp(game.happiness + rand(1, 3));
-        addLog(`Identity theft succeeded. You gained $${amount.toLocaleString()}.`);
+        addLog(`Identity theft succeeded. You gained $${amount.toLocaleString()}.`, 'crime');
       } else {
         if (rand(1, 100) <= 60) {
           game.inJail = true;
           game.jailYears = rand(1, 3);
-          addLog(`Identity theft failed. Jailed for ${game.jailYears} year(s).`);
+          addLog(`Identity theft failed. Jailed for ${game.jailYears} year(s).`, 'crime');
         } else {
           const fine = rand(200, 800);
           game.money = Math.max(game.money - fine, 0);
           game.health = clamp(game.health - rand(1, 4));
-          addLog(`Identity theft failed. You paid $${fine} in fines and were roughed up.`);
+          addLog(`Identity theft failed. You paid $${fine} in fines and were roughed up.`, 'crime');
         }
       }
     });
@@ -50,7 +50,7 @@ export function renderIdentity(container) {
     const cost = 150;
     if (game.money < cost) {
       applyAndSave(() => {
-        addLog('Name change costs $150. Not enough money.');
+        addLog('Name change costs $150. Not enough money.', 'identity');
       });
       return;
     }
@@ -63,7 +63,7 @@ export function renderIdentity(container) {
       const last = faker.person.lastName();
       game.name = `${first} ${last}`;
       game.happiness = clamp(game.happiness + rand(1, 3));
-      addLog(`You legally changed your name from ${oldName} to ${game.name}.`);
+      addLog(`You legally changed your name from ${oldName} to ${game.name}.`, 'identity');
     });
   });
   wrap.appendChild(legalBtn);

--- a/activities/lawsuit.js
+++ b/activities/lawsuit.js
@@ -16,7 +16,7 @@ export function renderLawsuit(container) {
     const cost = 5000;
     if (game.money < cost) {
       applyAndSave(() => {
-        addLog('Filing a lawsuit costs $5,000. Not enough money.');
+        addLog('Filing a lawsuit costs $5,000. Not enough money.', 'legal');
       });
       return;
     }
@@ -26,10 +26,10 @@ export function renderLawsuit(container) {
         const award = 25000;
         game.money += award;
         game.happiness = clamp(game.happiness + 5);
-        addLog(`You won the lawsuit and received $${award.toLocaleString()}.`);
+        addLog(`You won the lawsuit and received $${award.toLocaleString()}.`, 'legal');
       } else {
         game.happiness = clamp(game.happiness - 5);
-        addLog('You lost the lawsuit. The court dismissed your case.');
+        addLog('You lost the lawsuit. The court dismissed your case.', 'legal');
       }
     });
   });
@@ -42,7 +42,7 @@ export function renderLawsuit(container) {
     const cost = 3000;
     if (game.money < cost) {
       applyAndSave(() => {
-        addLog('Defending a lawsuit costs $3,000. Not enough money.');
+        addLog('Defending a lawsuit costs $3,000. Not enough money.', 'legal');
       });
       return;
     }
@@ -50,12 +50,12 @@ export function renderLawsuit(container) {
       game.money -= cost;
       if (rand(0, 1) === 1) {
         game.happiness = clamp(game.happiness + 2);
-        addLog('You successfully defended the lawsuit.');
+        addLog('You successfully defended the lawsuit.', 'legal');
       } else {
         const damages = 10000;
         game.money -= damages;
         game.happiness = clamp(game.happiness - 8);
-        addLog(`You lost the lawsuit and paid $${damages.toLocaleString()} in damages.`);
+        addLog(`You lost the lawsuit and paid $${damages.toLocaleString()} in damages.`, 'legal');
       }
     });
   });

--- a/activities/licenses.js
+++ b/activities/licenses.js
@@ -21,7 +21,7 @@ export function renderLicenses(container) {
       applyAndSave(() => {
         game.money -= opt.cost;
         game.licenses.push(opt.type);
-        addLog(`You obtained a ${opt.type}.`);
+        addLog(`You obtained a ${opt.type}.`, 'life');
       });
     });
     wrap.appendChild(btn);

--- a/activities/lottery.js
+++ b/activities/lottery.js
@@ -33,7 +33,7 @@ export function renderLottery(container) {
       }
       game.money += prize;
       game.happiness = clamp(game.happiness + mood);
-      addLog(msg);
+      addLog(msg, 'gambling');
     });
   });
   wrap.appendChild(btn);

--- a/activities/love.js
+++ b/activities/love.js
@@ -29,7 +29,7 @@ export function renderLove(container) {
       btn.addEventListener('click', () => {
         applyAndSave(() => {
           game.relationships.splice(i, 1);
-          addLog(`You broke up with ${rel.name}.`);
+          addLog(`You broke up with ${rel.name}.`, 'relationship');
         });
       });
       row.appendChild(btn);
@@ -47,7 +47,7 @@ export function renderLove(container) {
       const name = `${faker.person.firstName()} ${faker.person.lastName()}`;
       const partner = { name, happiness: rand(40, 80) };
       game.relationships.push(partner);
-      addLog(`You started dating ${name}.`);
+      addLog(`You started dating ${name}.`, 'relationship');
     });
   });
   wrap.appendChild(findBtn);
@@ -61,7 +61,7 @@ export function tickRelationships() {
       const r = game.relationships[i];
       r.happiness = clamp(r.happiness + rand(-10, 5));
       if (r.happiness <= 0) {
-        addLog(`${r.name} left you.`);
+        addLog(`${r.name} left you.`, 'relationship');
         game.relationships.splice(i, 1);
       }
     }

--- a/activities/luxuryLifestyle.js
+++ b/activities/luxuryLifestyle.js
@@ -23,7 +23,7 @@ export function renderLuxuryLifestyle(container) {
     btn.addEventListener('click', () => {
       if (game.money < item.cost) {
         applyAndSave(() => {
-          addLog(`${item.name} costs $${item.cost.toLocaleString()}. Not enough money.`);
+          addLog(`${item.name} costs $${item.cost.toLocaleString()}. Not enough money.`, 'luxury');
         });
         return;
       }
@@ -31,7 +31,7 @@ export function renderLuxuryLifestyle(container) {
         game.money -= item.cost;
         game.happiness = clamp(game.happiness + item.happiness);
         game.looks = clamp(game.looks + item.looks);
-        addLog(`You bought a ${item.name}. +${item.happiness} Happiness, +${item.looks} Looks.`);
+        addLog(`You bought a ${item.name}. +${item.happiness} Happiness, +${item.looks} Looks.`, 'luxury');
       });
     });
     list.appendChild(btn);

--- a/activities/mindAndWork.js
+++ b/activities/mindAndWork.js
@@ -19,7 +19,7 @@ export function renderMindAndWork(container) {
       applyAndSave(() => {
         const gain = rand(2, 5);
         game.happiness = clamp(game.happiness + gain);
-        addLog(`You meditated. +${gain} Happiness.`);
+        addLog(`You meditated. +${gain} Happiness.`, 'health');
       });
     })
   );
@@ -29,7 +29,7 @@ export function renderMindAndWork(container) {
       const cost = 100;
       if (game.money < cost) {
         applyAndSave(() => {
-          addLog(`Course costs $${cost}. Not enough money.`);
+          addLog(`Course costs $${cost}. Not enough money.`, 'education');
         });
         return;
       }
@@ -37,7 +37,7 @@ export function renderMindAndWork(container) {
         game.money -= cost;
         const gain = rand(4, 8);
         game.smarts = clamp(game.smarts + gain);
-        addLog(`You took a productivity course. +${gain} Smarts.`);
+        addLog(`You took a productivity course. +${gain} Smarts.`, 'education');
       });
     })
   );

--- a/activities/movieTheater.js
+++ b/activities/movieTheater.js
@@ -37,7 +37,7 @@ export function renderMovieTheater(container) {
       const event = EVENTS[rand(0, EVENTS.length - 1)];
       game.happiness = clamp(game.happiness + event.happiness);
       if (event.money) game.money += event.money;
-      addLog(event.text);
+      addLog(event.text, 'leisure');
       result.textContent = event.text;
     });
   });

--- a/activities/nightlife.js
+++ b/activities/nightlife.js
@@ -18,7 +18,7 @@ export function renderNightlife(container) {
       const cost = 20;
       if (game.money < cost) {
         applyAndSave(() => {
-          addLog('Not enough money to go clubbing.');
+          addLog('Not enough money to go clubbing.', 'leisure');
         });
         return;
       }
@@ -26,7 +26,7 @@ export function renderNightlife(container) {
         game.money -= cost;
         game.happiness = clamp(game.happiness + rand(4, 8));
         game.health = clamp(game.health - rand(0, 4));
-        addLog('You danced the night away at the club.');
+        addLog('You danced the night away at the club.', 'leisure');
       });
     })
   );
@@ -36,7 +36,7 @@ export function renderNightlife(container) {
       const cost = 15;
       if (game.money < cost) {
         applyAndSave(() => {
-          addLog('Not enough money to go bar hopping.');
+          addLog('Not enough money to go bar hopping.', 'leisure');
         });
         return;
       }
@@ -44,7 +44,7 @@ export function renderNightlife(container) {
         game.money -= cost;
         game.happiness = clamp(game.happiness + rand(2, 6));
         game.health = clamp(game.health - rand(0, 3));
-        addLog('You enjoyed a night of bar hopping.');
+        addLog('You enjoyed a night of bar hopping.', 'leisure');
       });
     })
   );

--- a/activities/outdoorLifestyle.js
+++ b/activities/outdoorLifestyle.js
@@ -35,7 +35,7 @@ export function renderOutdoorLifestyle(container) {
         const happinessGain = rand(opt.happiness[0], opt.happiness[1]);
         game.health = clamp(game.health + healthGain);
         game.happiness = clamp(game.happiness + happinessGain);
-        addLog(`You ${opt.log}. +${healthGain} Health, +${happinessGain} Happiness.`);
+        addLog(`You ${opt.log}. +${healthGain} Health, +${happinessGain} Happiness.`, 'health');
       });
     });
     wrap.appendChild(btn);

--- a/activities/pets.js
+++ b/activities/pets.js
@@ -28,14 +28,14 @@ export function renderPets(container) {
     btn.addEventListener('click', () => {
       if (game.money < a.cost) {
         applyAndSave(() => {
-          addLog('You cannot afford that pet.');
+          addLog('You cannot afford that pet.', 'pet');
         });
         return;
       }
       applyAndSave(() => {
         game.money -= a.cost;
         game.pets.push({ type: a.type, age: 0, happiness: 70 });
-        addLog(`You adopted a ${a.type}.`);
+        addLog(`You adopted a ${a.type}.`, 'pet');
       });
     });
     list.appendChild(btn);
@@ -61,7 +61,7 @@ export function renderPets(container) {
       play.addEventListener('click', () => {
         applyAndSave(() => {
           pet.happiness = Math.min(pet.happiness + 10, 100);
-          addLog(`You played with your ${pet.type}.`);
+          addLog(`You played with your ${pet.type}.`, 'pet');
         });
       });
       actions.appendChild(play);
@@ -72,7 +72,7 @@ export function renderPets(container) {
         applyAndSave(() => {
           pet.age += 1;
           pet.happiness = Math.max(pet.happiness - 5, 0);
-          addLog(`Your ${pet.type} aged a year.`);
+          addLog(`Your ${pet.type} aged a year.`, 'pet');
         });
       });
       actions.appendChild(ageBtn);

--- a/activities/plasticSurgery.js
+++ b/activities/plasticSurgery.js
@@ -19,14 +19,14 @@ export function renderPlasticSurgery(container) {
     btn.addEventListener('click', () => {
       if (game.money < p.cost) {
         applyAndSave(() => {
-          addLog(`Not enough money for ${p.name} ($${p.cost.toLocaleString()}).`);
+          addLog(`Not enough money for ${p.name} ($${p.cost.toLocaleString()}).`, 'health');
         });
         return;
       }
       applyAndSave(() => {
         game.money -= p.cost;
         game.looks = clamp(game.looks + p.gain);
-        addLog(`You underwent a ${p.name}. (-$${p.cost.toLocaleString()}, +Looks)`);
+        addLog(`You underwent a ${p.name}. (-$${p.cost.toLocaleString()}, +Looks)`, 'health');
       });
     });
     wrap.appendChild(btn);

--- a/activities/raceTracks.js
+++ b/activities/raceTracks.js
@@ -35,7 +35,7 @@ export function renderRaceTracks(container) {
           game.happiness = clamp(game.happiness - 5);
           msg = `You lost your bet at the ${track.label}.`;
         }
-        addLog(msg);
+        addLog(msg, 'gambling');
       });
     });
     wrap.appendChild(btn);

--- a/activities/racing.js
+++ b/activities/racing.js
@@ -18,12 +18,12 @@ export function renderRacing(container) {
         const prize = rand(200, 500);
         game.money += prize;
         game.happiness = clamp(game.happiness + rand(5, 10));
-        addLog(`You won a vehicle race and earned $${prize}.`);
+        addLog(`You won a vehicle race and earned $${prize}.`, 'leisure');
       } else {
         const dmg = rand(5, 15);
         game.health = clamp(game.health - dmg);
         game.happiness = clamp(game.happiness - rand(5, 10));
-        addLog(`You crashed during a vehicle race. -${dmg} Health.`);
+        addLog(`You crashed during a vehicle race. -${dmg} Health.`, 'leisure');
       }
     });
   });
@@ -38,12 +38,12 @@ export function renderRacing(container) {
         const gain = rand(5, 10);
         game.health = clamp(game.health + gain);
         game.happiness = clamp(game.happiness + rand(2, 6));
-        addLog(`You won the foot race. +${gain} Health.`);
+        addLog(`You won the foot race. +${gain} Health.`, 'leisure');
       } else {
         const loss = rand(2, 7);
         game.health = clamp(game.health - loss);
         game.happiness = clamp(game.happiness - rand(1, 4));
-        addLog(`You lost the foot race. -${loss} Health.`);
+        addLog(`You lost the foot race. -${loss} Health.`, 'leisure');
       }
     });
   });

--- a/activities/rehab.js
+++ b/activities/rehab.js
@@ -19,7 +19,7 @@ export function renderRehab(container) {
       const cost = 200;
       if (game.money < cost) {
         applyAndSave(() => {
-          addLog(`Therapy session costs $${cost}. Not enough money.`);
+          addLog(`Therapy session costs $${cost}. Not enough money.`, 'health');
         });
         return;
       }
@@ -27,7 +27,7 @@ export function renderRehab(container) {
         game.money -= cost;
         game.health = clamp(game.health + rand(1, 3));
         game.addiction = clamp(game.addiction - rand(2, 5));
-        addLog('Therapy session helped you recover. (+Health, -Addiction)');
+        addLog('Therapy session helped you recover. (+Health, -Addiction)', 'health');
       });
     })
   );
@@ -37,7 +37,7 @@ export function renderRehab(container) {
       const cost = 500;
       if (game.money < cost) {
         applyAndSave(() => {
-          addLog(`Detox program costs $${cost}. Not enough money.`);
+          addLog(`Detox program costs $${cost}. Not enough money.`, 'health');
         });
         return;
       }
@@ -45,7 +45,7 @@ export function renderRehab(container) {
         game.money -= cost;
         game.health = clamp(game.health + rand(4, 8));
         game.addiction = clamp(game.addiction - rand(5, 15));
-        addLog('You completed a detox program. (+Health, -Addiction)');
+        addLog('You completed a detox program. (+Health, -Addiction)', 'health');
       });
     })
   );
@@ -55,7 +55,7 @@ export function renderRehab(container) {
       const cost = 1000;
       if (game.money < cost) {
         applyAndSave(() => {
-          addLog(`Intensive rehab costs $${cost}. Not enough money.`);
+          addLog(`Intensive rehab costs $${cost}. Not enough money.`, 'health');
         });
         return;
       }
@@ -63,7 +63,7 @@ export function renderRehab(container) {
         game.money -= cost;
         game.health = clamp(game.health + rand(8, 15));
         game.addiction = clamp(game.addiction - rand(15, 30));
-        addLog('Intensive rehab significantly reduced your addiction. (+Health, -Addiction)');
+        addLog('Intensive rehab significantly reduced your addiction. (+Health, -Addiction)', 'health');
       });
     })
   );

--- a/activities/salonAndSpa.js
+++ b/activities/salonAndSpa.js
@@ -19,7 +19,7 @@ export function renderSalonAndSpa(container) {
       const cost = 40;
       if (game.money < cost) {
         applyAndSave(() => {
-          addLog(`Haircut costs $${cost}. Not enough money.`);
+          addLog(`Haircut costs $${cost}. Not enough money.`, 'health');
         });
         return;
       }
@@ -27,7 +27,7 @@ export function renderSalonAndSpa(container) {
         game.money -= cost;
         game.happiness = clamp(game.happiness + rand(1, 4));
         game.looks = clamp(game.looks + rand(1, 3));
-        addLog('You got a fresh haircut. (+Happiness, +Looks)');
+        addLog('You got a fresh haircut. (+Happiness, +Looks)', 'health');
       });
     })
   );
@@ -37,7 +37,7 @@ export function renderSalonAndSpa(container) {
       const cost = 80;
       if (game.money < cost) {
         applyAndSave(() => {
-          addLog(`Massage costs $${cost}. Not enough money.`);
+          addLog(`Massage costs $${cost}. Not enough money.`, 'health');
         });
         return;
       }
@@ -45,7 +45,7 @@ export function renderSalonAndSpa(container) {
         game.money -= cost;
         game.health = clamp(game.health + rand(2, 6));
         game.happiness = clamp(game.happiness + rand(2, 5));
-        addLog('The massage relaxed you. (+Health, +Happiness)');
+        addLog('The massage relaxed you. (+Health, +Happiness)', 'health');
       });
     })
   );

--- a/activities/secretAgent.js
+++ b/activities/secretAgent.js
@@ -8,12 +8,12 @@ const MISSIONS = [
       const cash = rand(500, 1500);
       game.money += cash;
       game.smarts = clamp(game.smarts + rand(1, 3));
-      addLog(`Intel mission succeeded. +$${cash} and Smarts.`);
+      addLog(`Intel mission succeeded. +$${cash} and Smarts.`, 'job');
     },
     fail() {
       const dmg = rand(5, 12);
       game.health = clamp(game.health - dmg);
-      addLog(`Intel mission failed. -${dmg} Health.`);
+      addLog(`Intel mission failed. -${dmg} Health.`, 'job');
     }
   },
   {
@@ -22,12 +22,12 @@ const MISSIONS = [
       const cash = rand(2000, 4000);
       game.money += cash;
       game.happiness = clamp(game.happiness + rand(1, 4));
-      addLog(`Sabotage successful. +$${cash} and Happiness.`);
+      addLog(`Sabotage successful. +$${cash} and Happiness.`, 'job');
     },
     fail() {
       const dmg = rand(10, 20);
       game.health = clamp(game.health - dmg);
-      addLog(`You were injured during sabotage. -${dmg} Health.`);
+      addLog(`You were injured during sabotage. -${dmg} Health.`, 'job');
     }
   },
   {
@@ -36,12 +36,12 @@ const MISSIONS = [
       const cash = rand(5000, 10000);
       game.money += cash;
       game.happiness = clamp(game.happiness + rand(2, 6));
-      addLog(`Assassination succeeded. +$${cash} and Happiness.`);
+      addLog(`Assassination succeeded. +$${cash} and Happiness.`, 'job');
     },
     fail() {
       const dmg = rand(15, 30);
       game.health = clamp(game.health - dmg);
-      addLog(`Assassination attempt failed. -${dmg} Health.`);
+      addLog(`Assassination attempt failed. -${dmg} Health.`, 'job');
     }
   }
 ];

--- a/activities/shopping.js
+++ b/activities/shopping.js
@@ -23,7 +23,7 @@ export function renderShopping(container) {
     btn.addEventListener('click', () => {
       if (game.money < item.cost) {
         applyAndSave(() => {
-          addLog(`You cannot afford ${item.name}.`);
+          addLog(`You cannot afford ${item.name}.`, 'shopping');
         });
         return;
       }
@@ -39,7 +39,7 @@ export function renderShopping(container) {
           game.money += gain;
           log += ` +$${gain}.`;
         }
-        addLog(log);
+        addLog(log, 'shopping');
       });
     });
     wrap.appendChild(btn);

--- a/activities/socialMedia.js
+++ b/activities/socialMedia.js
@@ -25,7 +25,7 @@ export function renderSocialMedia(container) {
       game.followers += gained;
       const gain = rand(1, 3);
       game.happiness = clamp(game.happiness + gain);
-      addLog(`You posted on social media and gained ${gained} followers.`);
+      addLog(`You posted on social media and gained ${gained} followers.`, 'social');
       count.textContent = `Followers: ${game.followers}`;
     });
   });
@@ -37,7 +37,7 @@ export function renderSocialMedia(container) {
     const cost = 100;
     if (game.money < cost) {
       applyAndSave(() => {
-        addLog('Promotion costs $100. Not enough money.');
+        addLog('Promotion costs $100. Not enough money.', 'social');
       });
       return;
     }
@@ -46,7 +46,7 @@ export function renderSocialMedia(container) {
       const gained = rand(50, 100);
       game.followers += gained;
       game.happiness = clamp(game.happiness + 5);
-      addLog(`You promoted your account and gained ${gained} followers.`);
+      addLog(`You promoted your account and gained ${gained} followers.`, 'social');
       count.textContent = `Followers: ${game.followers}`;
     });
   });

--- a/activities/vacation.js
+++ b/activities/vacation.js
@@ -14,7 +14,7 @@ export function renderVacation(container) {
     const cost = 500;
     if (game.money < cost) {
       applyAndSave(() => {
-        addLog('Vacation costs $500. Not enough money.');
+        addLog('Vacation costs $500. Not enough money.', 'travel');
       });
       return;
     }
@@ -22,7 +22,7 @@ export function renderVacation(container) {
       game.money -= cost;
       const gain = rand(8, 15);
       game.happiness = clamp(game.happiness + gain);
-      addLog(`You went on a vacation. +${gain} Happiness.`);
+      addLog(`You went on a vacation. +${gain} Happiness.`, 'travel');
     });
   });
 

--- a/activities/willAndTestament.js
+++ b/activities/willAndTestament.js
@@ -9,11 +9,11 @@ export function renderWillAndTestament(container) {
       action: () => {
         applyAndSave(() => {
           if (!game.relationships.length) {
-            addLog('You have no partner to leave your estate to.');
+            addLog('You have no partner to leave your estate to.', 'property');
           } else {
             const partner = game.relationships[0].name;
             game.inheritance = { [partner]: 1 };
-            addLog(`You updated your will: everything goes to ${partner}.`);
+            addLog(`You updated your will: everything goes to ${partner}.`, 'property');
           }
         });
       }
@@ -23,14 +23,14 @@ export function renderWillAndTestament(container) {
       action: () => {
         applyAndSave(() => {
           if (!game.children || game.children.length === 0) {
-            addLog('You have no children to inherit your estate.');
+            addLog('You have no children to inherit your estate.', 'property');
           } else {
             const share = 1 / game.children.length;
             game.inheritance = {};
             for (const child of game.children) {
               game.inheritance[child.name] = share;
             }
-            addLog('You updated your will to divide your estate among your children.');
+            addLog('You updated your will to divide your estate among your children.', 'property');
           }
         });
       }
@@ -40,7 +40,7 @@ export function renderWillAndTestament(container) {
       action: () => {
         applyAndSave(() => {
           game.inheritance = { Charity: 1 };
-          addLog('You updated your will to donate your estate to charity.');
+          addLog('You updated your will to donate your estate to charity.', 'property');
         });
       }
     }

--- a/activities/zoo.js
+++ b/activities/zoo.js
@@ -25,7 +25,7 @@ export function renderZoo(container) {
     btn.addEventListener('click', () => {
       if (game.money < ex.cost) {
         applyAndSave(() => {
-          addLog('You cannot afford that ticket.');
+          addLog('You cannot afford that ticket.', 'leisure');
         });
         return;
       }
@@ -37,7 +37,7 @@ export function renderZoo(container) {
           game.smarts = clamp(game.smarts + ex.gain);
         }
         const statName = ex.stat === 'smarts' ? 'Smarts' : 'Happiness';
-        addLog(`You visited the ${ex.name}. +${ex.gain} ${statName}.`);
+        addLog(`You visited the ${ex.name}. +${ex.gain} ${statName}.`, 'leisure');
       });
     });
     list.appendChild(btn);

--- a/activities/zooTrip.js
+++ b/activities/zooTrip.js
@@ -45,7 +45,7 @@ export function renderZooTrip(container) {
     const cost = trip.cost * people;
     if (game.money < cost) {
       applyAndSave(() => {
-        addLog(`Zoo trip costs $${cost}. Not enough money.`);
+        addLog(`Zoo trip costs $${cost}. Not enough money.`, 'leisure');
       });
       return;
     }
@@ -53,7 +53,10 @@ export function renderZooTrip(container) {
       game.money -= cost;
       const mood = trip.mood * people;
       game.happiness = clamp(game.happiness + mood);
-      addLog(`You visited the ${trip.name.toLowerCase()} with ${people} ${people === 1 ? 'person' : 'people'}. +${mood} Happiness.`);
+      addLog(
+        `You visited the ${trip.name.toLowerCase()} with ${people} ${people === 1 ? 'person' : 'people'}. +${mood} Happiness.`,
+        'leisure'
+      );
     });
   });
   wrap.appendChild(btn);

--- a/jail.js
+++ b/jail.js
@@ -7,7 +7,7 @@ export function tickJail() {
   if (game.jailYears <= 0) {
     game.inJail = false;
     delete game.jailYears;
-    addLog('You were released from jail.');
+    addLog('You were released from jail.', 'crime');
   }
   saveGame();
 }

--- a/realestate.js
+++ b/realestate.js
@@ -173,7 +173,7 @@ export async function initBrokers() {
 
 export function buyProperty(broker, listing) {
   if (game.money < listing.value) {
-    addLog(`Not enough money to buy ${listing.name}.`);
+    addLog(`Not enough money to buy ${listing.name}.`, 'property');
     saveGame();
     return false;
   }
@@ -191,7 +191,8 @@ export function buyProperty(broker, listing) {
   game.properties.push(prop);
   broker.listings = broker.listings.filter(l => l !== listing);
   addLog(
-    `You bought ${listing.name} from ${broker.name} for $${listing.value.toLocaleString()}.`
+    `You bought ${listing.name} from ${broker.name} for $${listing.value.toLocaleString()}.`,
+    'property'
   );
   saveGame();
   return true;
@@ -200,13 +201,13 @@ export function buyProperty(broker, listing) {
 export function sellProperty(prop) {
   game.money += prop.value;
   game.properties = game.properties.filter(p => p !== prop);
-  addLog(`You sold ${prop.name} for $${prop.value.toLocaleString()}.`);
+  addLog(`You sold ${prop.name} for $${prop.value.toLocaleString()}.`, 'property');
   saveGame();
 }
 
 export function rentProperty(prop, percent) {
   if (prop.rented) {
-    addLog(`${prop.name} is already rented.`);
+    addLog(`${prop.name} is already rented.`, 'property');
     saveGame();
     return;
   }
@@ -216,14 +217,14 @@ export function rentProperty(prop, percent) {
   prop.rented = true;
   prop.rent = rent;
   prop.tenant = tenant;
-  addLog(`You rented ${prop.name} to ${tenant} for $${rent.toLocaleString()} per year.`);
+  addLog(`You rented ${prop.name} to ${tenant} for $${rent.toLocaleString()} per year.`, 'property');
   saveGame();
 }
 
 export function repairProperty(prop, percent) {
   const cost = Math.round(prop.value * percent / 100);
   if (game.money < cost) {
-    addLog(`Repairing ${prop.name} costs $${cost.toLocaleString()}. Not enough money.`);
+    addLog(`Repairing ${prop.name} costs $${cost.toLocaleString()}. Not enough money.`, 'property');
     saveGame();
     return;
   }
@@ -237,9 +238,9 @@ export function repairProperty(prop, percent) {
   const roll = rand(1, 100);
   if (roll <= chance) {
     prop.condition = 100;
-    addLog(`Repair succeeded on ${prop.name}.`);
+    addLog(`Repair succeeded on ${prop.name}.`, 'property');
   } else {
-    addLog(`Repair failed on ${prop.name}.`);
+    addLog(`Repair failed on ${prop.name}.`, 'property');
   }
   saveGame();
 }

--- a/renderers/jobs.js
+++ b/renderers/jobs.js
@@ -38,13 +38,13 @@ export function renderJobs(container) {
     e.title = ok ? 'Take job' : 'Your Smarts are too low for this role';
     e.addEventListener('click', () => {
       if (!ok) {
-        addLog('You were not qualified for that role. (+Study to improve Smarts)');
+        addLog('You were not qualified for that role. (+Study to improve Smarts)', 'job');
         refreshOpenWindows();
         saveGame();
         return;
       }
       game.job = j;
-      addLog(`You became a ${j.title}. Salary $${j.salary.toLocaleString()}/yr.`);
+      addLog(`You became a ${j.title}. Salary $${j.salary.toLocaleString()}/yr.`, 'job');
       refreshOpenWindows();
       saveGame();
     });

--- a/renderers/log.js
+++ b/renderers/log.js
@@ -1,20 +1,46 @@
 import { game } from '../state.js';
 
 export function renderLog(container) {
+  const categories = Array.from(new Set(game.log.map(l => l.category || 'general')));
+  const select = document.createElement('select');
+  const allOpt = document.createElement('option');
+  allOpt.value = 'all';
+  allOpt.textContent = 'All';
+  select.appendChild(allOpt);
+  for (const cat of categories) {
+    const opt = document.createElement('option');
+    opt.value = cat;
+    opt.textContent = cat.charAt(0).toUpperCase() + cat.slice(1);
+    select.appendChild(opt);
+  }
+  container.appendChild(select);
+
   const list = document.createElement('div');
   list.className = 'log';
-  if (game.log.length === 0) {
-    const e = document.createElement('div');
-    e.className = 'entry';
-    e.textContent = 'Your story will appear here.';
-    list.appendChild(e);
-  } else {
-    for (const item of game.log) {
+  container.appendChild(list);
+
+  const renderList = () => {
+    list.innerHTML = '';
+    const selected = select.value;
+    const items =
+      selected === 'all'
+        ? game.log
+        : game.log.filter(item => item.category === selected);
+    if (items.length === 0) {
       const e = document.createElement('div');
       e.className = 'entry';
-      e.innerHTML = `<div>${item.text}</div><time>${item.when}</time>`;
+      e.textContent = 'Your story will appear here.';
       list.appendChild(e);
+    } else {
+      for (const item of items) {
+        const e = document.createElement('div');
+        e.className = 'entry';
+        e.innerHTML = `<div>${item.text}</div><time>${item.when}</time>`;
+        list.appendChild(e);
+      }
     }
-  }
-  container.appendChild(list);
+  };
+
+  select.addEventListener('change', renderList);
+  renderList();
 }

--- a/script.js
+++ b/script.js
@@ -15,7 +15,7 @@ if ('serviceWorker' in navigator) {
     navigator.serviceWorker.register('/service-worker.js')
       .catch(err => {
         console.error('SW registration failed', err);
-        addLog('Service worker registration failed.');
+        addLog('Service worker registration failed.', 'general');
       });
   });
 }

--- a/state.js
+++ b/state.js
@@ -58,9 +58,9 @@ export const game = {
  * @param {string} text - Message to record in the log.
  * @returns {void}
  */
-export function addLog(text) {
+export function addLog(text, category = 'general') {
   const when = `${game.year} • age ${game.age}`;
-  game.log.unshift({ when, text });
+  game.log.unshift({ when, text, category });
   if (game.log.length > 200) game.log.pop();
   refreshOpenWindows();
 }
@@ -72,7 +72,7 @@ export function addLog(text) {
  */
 export function die(reason) {
   game.alive = false;
-  addLog(reason);
+  addLog(reason, 'life');
   showEndScreen(game);
 }
 
@@ -168,7 +168,7 @@ export function newLife(genderInput, nameInput) {
     log: []
   });
   initBrokers();
-  addLog('You were born. A new life begins.');
+  addLog('You were born. A new life begins.', 'life');
   refreshOpenWindows();
   saveGame();
 }


### PR DESCRIPTION
## Summary
- Extend `addLog` to track log categories
- Categorize existing log entries across game activities
- Add log window filter for viewing entries by category

## Testing
- `npm test` *(fails: Cannot find module '/workspace/JustAnotherTestrepo/node_modules/jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_68b8c48a5ccc832a8a0296340cc07721