### PR TITLE
Add achievements system

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -1,4 +1,4 @@
-import { game, addLog, die, saveGame, applyAndSave } from './state.js';
+import { game, addLog, die, saveGame, applyAndSave, unlockAchievement } from './state.js';
 import { rand, clamp } from './utils.js';
 import { tickJail } from './jail.js';
 import { tickRelationships } from './activities/love.js';
@@ -63,6 +63,12 @@ export function ageUp() {
     paySalary();
     randomEvent();
     tickRealEstate();
+    if (game.job) {
+      unlockAchievement('first-job', 'Got your first job.');
+    }
+    if (game.properties.length > 0) {
+      unlockAchievement('first-property', 'Bought your first property.');
+    }
     if (game.age >= game.maxAge) {
       game.alive = false;
       addLog('You died of old age.');

--- a/partials/dock.html
+++ b/partials/dock.html
@@ -7,6 +7,7 @@
   <button data-toggle="log" role="button" aria-label="Open Log window">Log</button>
   <button data-toggle="jobs" role="button" aria-label="Open Job Hunt window">Job Hunt</button>
   <button data-toggle="realestate" role="button" aria-label="Open Real Estate window">Real Estate</button>
+  <button data-toggle="achievements" role="button" aria-label="Open Achievements window">Achievements</button>
   <button data-toggle="help" role="button" aria-label="Open Help window">Help</button>
   <button data-toggle="newLife" role="button" aria-label="Start a new life">New Life</button>
   <button id="closeAll" role="button" aria-label="Close all windows">Close All</button>

--- a/realestate.js
+++ b/realestate.js
@@ -1,4 +1,4 @@
-import { game, addLog, saveGame } from './state.js';
+import { game, addLog, saveGame, unlockAchievement } from './state.js';
 import { rand, clamp } from './utils.js';
 import { faker as fallbackFaker } from './nameGenerator.js';
 
@@ -193,6 +193,9 @@ export function buyProperty(broker, listing) {
   addLog(
     `You bought ${listing.name} from ${broker.name} for $${listing.value.toLocaleString()}.`
   );
+  if (game.properties.length === 1) {
+    unlockAchievement('first-property', 'Bought your first property.');
+  }
   saveGame();
   return true;
 }

--- a/renderers/achievements.js
+++ b/renderers/achievements.js
@@ -1,0 +1,19 @@
+import { game } from '../state.js';
+
+export function renderAchievements(container) {
+  const list = document.createElement('div');
+  list.className = 'achievements';
+  if (game.achievements.length === 0) {
+    const e = document.createElement('div');
+    e.textContent = 'No achievements unlocked yet.';
+    list.appendChild(e);
+  } else {
+    for (const a of game.achievements) {
+      const e = document.createElement('div');
+      e.className = 'entry';
+      e.textContent = a.text;
+      list.appendChild(e);
+    }
+  }
+  container.appendChild(list);
+}

--- a/renderers/jobs.js
+++ b/renderers/jobs.js
@@ -1,4 +1,4 @@
-import { game, addLog, saveGame } from '../state.js';
+import { game, addLog, saveGame, unlockAchievement } from '../state.js';
 import { generateJobs } from '../jobs.js';
 import { refreshOpenWindows } from '../windowManager.js';
 
@@ -45,6 +45,7 @@ export function renderJobs(container) {
       }
       game.job = j;
       addLog(`You became a ${j.title}. Salary $${j.salary.toLocaleString()}/yr.`);
+      unlockAchievement('first-job', 'Got your first job.');
       refreshOpenWindows();
       saveGame();
     });

--- a/script.js
+++ b/script.js
@@ -9,6 +9,7 @@ import { renderActivities } from './renderers/activities.js';
 import { renderRealEstate } from './renderers/realestate.js';
 import { renderHelp } from './renderers/help.js';
 import { renderNewLife } from './renderers/newlife.js';
+import { renderAchievements } from './renderers/achievements.js';
 
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
@@ -119,6 +120,7 @@ registerWindow('jobs', 'Jobs', renderJobs);
 registerWindow('character', 'Character', renderCharacter);
 registerWindow('activities', 'Activities', renderActivities);
 registerWindow('realestate', 'Real Estate', renderRealEstate);
+registerWindow('achievements', 'Achievements', renderAchievements);
 registerWindow('help', 'Help', renderHelp);
 registerWindow('newLife', 'New Life', renderNewLife);
 

--- a/state.js
+++ b/state.js
@@ -43,6 +43,7 @@ export const game = {
   jobListingsYear: null,
   relationships: [],
   inheritance: null,
+  achievements: [],
   gender: '',
   name: '',
   city: '',
@@ -63,6 +64,13 @@ export function addLog(text) {
   game.log.unshift({ when, text });
   if (game.log.length > 200) game.log.pop();
   refreshOpenWindows();
+}
+
+export function unlockAchievement(id, text) {
+  if (game.achievements.some(a => a.id === id)) return;
+  game.achievements.push({ id, text });
+  addLog(`Achievement unlocked: ${text}`);
+  saveGame();
 }
 
 /**
@@ -158,6 +166,7 @@ export function newLife(genderInput, nameInput) {
     jobListingsYear: null,
     relationships: [],
     inheritance: null,
+    achievements: [],
     gender,
     name,
     city,


### PR DESCRIPTION
## Summary
- Track unlocked achievements in game state and persist them
- Provide Achievements window and dock button for viewing progress
- Unlock achievements for first job and first property purchase

## Testing
- `npm test` *(fails: Cannot find module '/workspace/JustAnotherTestrepo/node_modules/jest/bin/jest.js')*


------
https://chatgpt.com/codex/tasks/task_e_68b8c47684f4832ab4be92d6fbe8bb20