### PR TITLE
Add graduate education levels and jobs

### DIFF
--- a/jobs.js
+++ b/jobs.js
@@ -264,7 +264,9 @@ const jobFields = {
       ['Science Director', 110000, 'university'],
       ['Chief Environmental Scientist', 105000, 'university'],
       ['Astrophysicist', 120000, 'university'],
-      ['Chief Data Scientist', 115000, 'university']
+      ['Chief Data Scientist', 115000, 'university'],
+      ['Research Director', 125000, 'masters'],
+      ['Principal Investigator', 140000, 'phd']
     ]
   },
   transportation: {

--- a/school.js
+++ b/school.js
@@ -1,13 +1,15 @@
 import { game, addLog, applyAndSave, saveGame } from './state.js';
 
-export const EDU_LEVELS = ['none', 'elementary', 'middle', 'high', 'college', 'university'];
+export const EDU_LEVELS = ['none', 'elementary', 'middle', 'high', 'college', 'university', 'masters', 'phd'];
 
 const durations = {
   elementary: 6,
   middle: 3,
   high: 4,
   college: 4,
-  university: 4
+  university: 4,
+  masters: 2,
+  phd: 4
 };
 
 export function educationRank(level) {
@@ -26,6 +28,10 @@ export function eduName(level) {
       return 'College';
     case 'university':
       return 'University';
+    case 'masters':
+      return "Master's Degree";
+    case 'phd':
+      return 'PhD';
     default:
       return 'No School';
   }
@@ -96,6 +102,31 @@ export function enrollUniversity() {
   }
   applyAndSave(() => {
     startStage('university');
+  });
+}
+
+export function enrollMasters() {
+  if (
+    ['college', 'university'].indexOf(game.education.highest) === -1 ||
+    game.education.current
+  ) {
+    addLog('You need a college or university degree first.', 'education');
+    saveGame();
+    return;
+  }
+  applyAndSave(() => {
+    startStage('masters');
+  });
+}
+
+export function enrollPhd() {
+  if (game.education.highest !== 'masters' || game.education.current) {
+    addLog("You need a master's degree first.", 'education');
+    saveGame();
+    return;
+  }
+  applyAndSave(() => {
+    startStage('phd');
   });
 }
 


### PR DESCRIPTION
## Summary
- add master's and PhD levels with durations and friendly names
- allow enrolling in master's and PhD programs
- add senior science jobs requiring master's and PhD degrees

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8d984a030832aabaa8fe10cf80f22