### PR TITLE
feat: add trade school level and related jobs

### DIFF
--- a/jobs.js
+++ b/jobs.js
@@ -11,7 +11,8 @@ const jobFields = {
       ['QA Tester', 38000, 'high'],
       ['Computer Operator', 36000, 'high'],
       ['Technical Writer', 42000, 'college'],
-      ['Junior Developer', 42000, 'college']
+      ['Junior Developer', 42000, 'college'],
+      ['Computer Technician', 35000, 'trade']
     ],
     mid: [
       ['Systems Administrator', 60000, 'college'],
@@ -22,7 +23,8 @@ const jobFields = {
       ['DevOps Engineer', 74000, 'college'],
       ['UX Designer', 68000, 'college'],
       ['Engineer', 52000, 'university'],
-      ['Systems Analyst', 61000, 'college']
+      ['Systems Analyst', 61000, 'college'],
+      ['IT Specialist', 55000, 'trade']
     ],
     senior: [
       ['Senior Software Engineer', 90000, 'university'],
@@ -286,7 +288,8 @@ const jobFields = {
       ['Warehouse Manager', 48000, 'high'],
       ['Aviation Technician', 52000, 'college'],
       ['Railway Conductor', 46000, 'high'],
-      ['Maritime Navigator', 55000, 'college']
+      ['Maritime Navigator', 55000, 'college'],
+      ['Diesel Mechanic', 47000, 'trade']
     ],
     senior: [
       ['Airline Pilot', 120000, 'university'],

--- a/school.js
+++ b/school.js
@@ -1,10 +1,11 @@
 import { game, addLog, applyAndSave, saveGame } from './state.js';
 
-export const EDU_LEVELS = ['none', 'elementary', 'middle', 'high', 'college', 'university'];
+export const EDU_LEVELS = ['none', 'elementary', 'middle', 'trade', 'high', 'college', 'university'];
 
 const durations = {
   elementary: 6,
   middle: 3,
+  trade: 2,
   high: 4,
   college: 4,
   university: 4
@@ -20,6 +21,8 @@ export function eduName(level) {
       return 'Elementary School';
     case 'middle':
       return 'Middle School';
+    case 'trade':
+      return 'Trade School';
     case 'high':
       return 'High School';
     case 'college':
@@ -46,6 +49,8 @@ export function advanceSchool() {
     } else if (edu.highest === 'elementary') {
       startStage('middle');
     } else if (edu.highest === 'middle') {
+      startStage('trade');
+    } else if (edu.highest === 'trade') {
       startStage('high');
     }
   }


### PR DESCRIPTION
## Summary
- add trade school education level with name and duration
- allow progressing from middle school to trade school and back to high school
- introduce computer technician, IT specialist, and diesel mechanic jobs requiring trade school

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8d98c62a4832ab79b9b5347b0f391