### PR TITLE
Add high school re-enroll and GED options

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -451,3 +451,5 @@ export function crime() {
   });
 }
 
+export { dropOut, enrollCollege, enrollUniversity, reEnrollHighSchool, getGed } from './school.js';
+

--- a/renderers/actions.js
+++ b/renderers/actions.js
@@ -1,6 +1,5 @@
 import { game } from '../state.js';
-import { ageUp, study, meditate, hitGym, workExtra, seeDoctor, crime } from '../actions.js';
-import { dropOut, enrollCollege, enrollUniversity } from '../school.js';
+import { ageUp, study, meditate, hitGym, workExtra, seeDoctor, crime, dropOut, enrollCollege, enrollUniversity, reEnrollHighSchool, getGed } from '../actions.js';
 import { toggleWindow } from '../windowManager.js';
 import { renderJobs } from './jobs.js';
 
@@ -26,6 +25,12 @@ export function renderActions(container) {
   g.appendChild(mk('🕶️ Crime (risky)', crime, dead));
   if (!dead && game.age >= 16 && game.education.current === 'high' && !game.education.droppedOut) {
     g.appendChild(mk('🚪 Drop Out of School', dropOut));
+  }
+  if (!dead && game.education.droppedOut && !game.education.current) {
+    g.appendChild(mk('🏫 Re-Enroll in High School', reEnrollHighSchool));
+    if (game.education.highest !== 'high') {
+      g.appendChild(mk('📘 Get GED', getGed));
+    }
   }
   if (!dead && !game.education.current && game.education.highest === 'high') {
     g.appendChild(mk('🎓 Attend College', enrollCollege));

--- a/school.js
+++ b/school.js
@@ -77,6 +77,33 @@ export function dropOut() {
   });
 }
 
+export function reEnrollHighSchool() {
+  if (!game.education.droppedOut || game.education.current) {
+    addLog('You cannot re-enroll right now.', 'education');
+    saveGame();
+    return;
+  }
+  applyAndSave(() => {
+    game.education.droppedOut = false;
+    startStage('high');
+  });
+}
+
+export function getGed() {
+  if (game.education.highest === 'high' || game.education.current) {
+    addLog('You cannot get a GED right now.', 'education');
+    saveGame();
+    return;
+  }
+  applyAndSave(() => {
+    game.education.highest = 'high';
+    game.education.current = null;
+    game.education.progress = 0;
+    game.education.droppedOut = false;
+    addLog('You obtained a GED.', 'education');
+  });
+}
+
 export function enrollCollege() {
   if (game.education.highest !== 'high' || game.education.current) {
     addLog('You need a high school diploma first.', 'education');


### PR DESCRIPTION
## Summary
- Allow returning to high school by clearing dropout status and restarting the stage
- Offer a GED path that grants a high school diploma without re-enrollment
- Surface new school options in the actions list and re-export school actions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8d98fed9c832a87ccebf2af0ffb93