### PR TITLE
Fix service worker registration path

### DIFF
--- a/script.js
+++ b/script.js
@@ -14,7 +14,7 @@ import { renderSettings } from './renderers/settings.js';
 
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/service-worker.js')
+    navigator.serviceWorker.register('service-worker.js')
       .catch(err => {
         console.error('SW registration failed', err);
         addLog('Service worker registration failed.', 'general');

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,18 +1,18 @@
 const CACHE_VERSION = 'v1';
 const CACHE_NAME = `tiny-life-cache-${CACHE_VERSION}`;
 const CORE_ASSETS = [
-  '/index.html',
-  '/base.css',
-  '/components.css',
-  '/variables.css',
-  '/script.js',
-  '/actions.js',
-  '/state.js',
-  '/windowManager.js',
-  '/utils.js',
-  '/storyNet.js',
-  '/partials/dock.html',
-  '/partials/window-template.html'
+  'index.html',
+  'base.css',
+  'components.css',
+  'variables.css',
+  'script.js',
+  'actions.js',
+  'state.js',
+  'windowManager.js',
+  'utils.js',
+  'storyNet.js',
+  'partials/dock.html',
+  'partials/window-template.html'
 ];
 
 self.addEventListener('install', event => {


### PR DESCRIPTION
## Summary
- register service worker with a relative path to prevent 404 errors
- use relative asset paths in the service worker cache list

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8df8f1f08832aa0654afc06107712