### PR TITLE
Hide death screen before opening new life window

### DIFF
--- a/endscreen.js
+++ b/endscreen.js
@@ -56,6 +56,7 @@ export function showEndScreen(game) {
   const restart = document.createElement('button');
   restart.textContent = 'Start new life';
   restart.addEventListener('click', () => {
+    hideEndScreen();
     openWindow('newLife', 'New Life', renderNewLife);
   });
   screenEl.appendChild(restart);


### PR DESCRIPTION
## Summary
- Ensure the death screen hides before opening the "Start new life" window so it displays above other UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b8e15f2fb0832a91e45e2eb98ee4af