### PR TITLE
Add random start years and historical job availability

### DIFF
--- a/jobs.js
+++ b/jobs.js
@@ -187,7 +187,7 @@ const jobFields = {
       ['Server', 26000, 'none'],
       ['Hotel Housekeeper', 25000, 'none'],
       ['Front Desk Clerk', 27000, 'none'],
-      ['Barista', 22000, 'none'],
+      ['Barista', 22000, 'none', 1900],
       ['Host', 24000, 'none'],
       ['Line Cook', 28000, 'none'],
       ['Bellhop', 26000, 'none']
@@ -304,18 +304,37 @@ const jobFields = {
   } 
 };
 
+const fieldDiscoveryYear = {
+  technology: 1940
+};
+
+const jobDiscoveryYear = {
+  'Auto Mechanic Trainee': 1890,
+  'Auto Mechanic': 1890,
+  'Auto Shop Owner': 1890,
+  'Diesel Mechanic': 1920,
+  'HVAC Trainee': 1902,
+  'HVAC Technician': 1902,
+  'Senior HVAC Engineer': 1902,
+  'Airline Pilot': 1914,
+  'Flight Attendant': 1914,
+  'Aviation Technician': 1914
+};
+
 const partTimeJobs = [
-  ['Barista', 22000, 'none'],
-  ['Retail Clerk', 20000, 'none'],
-  ['Tutor', 25000, 'high'],
-  ['Dog Walker', 18000, 'none'],
-  ['Library Assistant', 21000, 'none']
+  ['Barista', 22000, 'none', 1900],
+  ['Retail Clerk', 20000, 'none', 1900],
+  ['Tutor', 25000, 'high', 1900],
+  ['Dog Walker', 18000, 'none', 1900],
+  ['Library Assistant', 21000, 'none', 1900]
 ];
 
 const allJobs = [];
 for (const [field, levels] of Object.entries(jobFields)) {
+  const fieldYear = fieldDiscoveryYear[field] || 0;
   for (const [level, jobs] of Object.entries(levels)) {
     for (const [title, base, edu, major] of jobs) {
+      const availableFrom = jobDiscoveryYear[title] || fieldYear;
       allJobs.push({
         field,
         level,
@@ -323,7 +342,8 @@ for (const [field, levels] of Object.entries(jobFields)) {
         base,
         reqEdu: edu,
         reqMajor: major,
-        tuitionAssistance: ['education', 'healthcare', 'law'].includes(field)
+        tuitionAssistance: ['education', 'healthcare', 'law'].includes(field),
+        availableFrom
       });
     }
   }
@@ -334,9 +354,10 @@ export function generateJobs() {
     return game.jobListings;
   }
   const options = [];
-  if (game.education.current !== null) {
+  const partTimePool = partTimeJobs.filter(j => j[3] <= game.year);
+  if (game.education.current !== null && partTimePool.length) {
     for (let i = 0; i < 2; i++) {
-      const job = partTimeJobs[rand(0, partTimeJobs.length - 1)];
+      const job = partTimePool[rand(0, partTimePool.length - 1)];
       const salary = job[1] + rand(-1000, 3000);
       options.push({
         title: job[0],
@@ -351,8 +372,9 @@ export function generateJobs() {
   const econ = game.economy;
   const count = econ === 'boom' ? 8 : econ === 'recession' ? 4 : 6;
   const mod = econ === 'boom' ? 1.2 : econ === 'recession' ? 0.8 : 1;
-  for (let i = 0; i < count; i++) {
-    const job = allJobs[rand(0, allJobs.length - 1)];
+  const jobPool = allJobs.filter(j => j.availableFrom <= game.year);
+  for (let i = 0; i < count && jobPool.length; i++) {
+    const job = jobPool[rand(0, jobPool.length - 1)];
     const salary = Math.round((job.base + rand(-3000, 12000)) * mod);
     options.push({
       title: job.title,

--- a/state.js
+++ b/state.js
@@ -27,7 +27,7 @@ export function storageAvailable() {
 }
 
 export const game = {
-  year: new Date().getFullYear(),
+  year: rand(1900, new Date().getFullYear()),
   age: 0,
   maxAge: rand(80, 120),
   health: 80,
@@ -145,7 +145,8 @@ export function newLife(genderInput, nameInput) {
  * Starts a new life, resetting the game state and prompting for basic info.
  * @returns {void}
  */
-  const now = new Date().getFullYear();
+  const currentYear = new Date().getFullYear();
+  const startYear = rand(1900, currentYear);
   hideEndScreen();
   localStorage.removeItem('gameState');
   let gender = genderInput?.trim();
@@ -166,47 +167,47 @@ export function newLife(genderInput, nameInput) {
   }
   const city = faker.location.city();
   const country = faker.location.country();
-    Object.assign(game, {
-      year: now,
-      age: 0,
-      maxAge: rand(80, 120),
-      health: 80,
-      happiness: 70,
-      smarts: 65,
-      looks: 50,
-      addiction: 0,
-      money: 0,
-      loanBalance: 0,
-      economy: 'normal',
-      loanInterestRate: 0.05,
-      followers: 0,
-      properties: [],
-      job: null,
-      jobSatisfaction: 50,
-      jobPerformance: 50,
-      jobExperience: 0,
-      jobLevel: null,
-      jobListings: [],
-      jobListingsYear: null,
-      relationships: [],
-      inheritance: null,
-      achievements: [],
-      education: {
-        current: null,
-        highest: 'none',
-        progress: 0,
-        droppedOut: false,
-        major: null
-      },
-      gender,
-      name,
-      city,
-      country,
-      sick: false,
-      inJail: false,
-      alive: true,
-      log: []
-    });
+  Object.assign(game, {
+    year: startYear,
+    age: 0,
+    maxAge: rand(80, 120),
+    health: 80,
+    happiness: 70,
+    smarts: 65,
+    looks: 50,
+    addiction: 0,
+    money: 0,
+    loanBalance: 0,
+    economy: 'normal',
+    loanInterestRate: 0.05,
+    followers: 0,
+    properties: [],
+    job: null,
+    jobSatisfaction: 50,
+    jobPerformance: 50,
+    jobExperience: 0,
+    jobLevel: null,
+    jobListings: [],
+    jobListingsYear: null,
+    relationships: [],
+    inheritance: null,
+    achievements: [],
+    education: {
+      current: null,
+      highest: 'none',
+      progress: 0,
+      droppedOut: false,
+      major: null
+    },
+    gender,
+    name,
+    city,
+    country,
+    sick: false,
+    inJail: false,
+    alive: true,
+    log: []
+  });
   initBrokers();
   addLog([
     'You were born. A new life begins.',


### PR DESCRIPTION
## Summary
- start each life in a random year rather than the current year
- restrict job listings by discovery year so unavailable careers (e.g. tech before 1940) are filtered out
- add job-level discovery years for auto mechanics, HVAC roles, and early aviation jobs to better reflect historical availability

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8e1d6f3c4832aa91aacd63d052bfa