### PR TITLE
feat: add cache versioning and offline fallback

### DIFF
--- a/offline.html
+++ b/offline.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Offline</title>
+</head>
+<body>
+  <p>You are offline.</p>
+</body>
+</html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,11 @@
 const CACHE_VERSION = 'v1';
+export function bumpCacheVersion(version = CACHE_VERSION) {
+  const match = version.match(/(\d+)$/);
+  const num = match ? parseInt(match[1], 10) : 0;
+  return `v${num + 1}`;
+}
 const CACHE_NAME = `tiny-life-cache-${CACHE_VERSION}`;
+export const OFFLINE_URL = 'offline.html';
 const CORE_ASSETS = [
   'index.html',
   'base.css',
@@ -12,48 +18,51 @@ const CORE_ASSETS = [
   'utils.js',
   'storyNet.js',
   'partials/dock.html',
-  'partials/window-template.html'
+  'partials/window-template.html',
+  OFFLINE_URL
 ];
 
-self.addEventListener('install', event => {
-  event.waitUntil(
-    caches.open(CACHE_NAME).then(cache => cache.addAll(CORE_ASSETS))
-  );
-});
+export async function handleFetch(request) {
+  const cache = await caches.open(CACHE_NAME);
+  const cachedResponse = await cache.match(request);
+  try {
+    const networkResponse = await fetch(request);
+    if (networkResponse && networkResponse.ok) {
+      cache.put(request, networkResponse.clone());
+      const whitelist = new Set(
+        CORE_ASSETS.map(asset => new URL(asset, self.location).href)
+      );
+      whitelist.add(request.url);
+      cache.keys().then(keys => {
+        keys.forEach(key => {
+          if (!whitelist.has(key.url)) {
+            cache.delete(key);
+          }
+        });
+      });
+    }
+    return networkResponse;
+  } catch (_) {
+    return cachedResponse || caches.match(OFFLINE_URL);
+  }
+}
 
-self.addEventListener('activate', event => {
-  event.waitUntil(
-    caches.keys().then(keys => Promise.all(
-      keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))
-    ))
-  );
-});
+if (typeof self !== 'undefined') {
+  self.addEventListener('install', event => {
+    event.waitUntil(
+      caches.open(CACHE_NAME).then(cache => cache.addAll(CORE_ASSETS))
+    );
+  });
 
-self.addEventListener('fetch', event => {
-  event.respondWith(
-    caches.open(CACHE_NAME).then(cache =>
-      cache.match(event.request).then(cachedResponse => {
-        const fetchPromise = fetch(event.request)
-          .then(networkResponse => {
-            if (networkResponse && networkResponse.ok) {
-              cache.put(event.request, networkResponse.clone());
-              const whitelist = new Set(
-                CORE_ASSETS.map(asset => new URL(asset, self.location).href)
-              );
-              whitelist.add(event.request.url);
-              cache.keys().then(keys => {
-                keys.forEach(key => {
-                  if (!whitelist.has(key.url)) {
-                    cache.delete(key);
-                  }
-                });
-              });
-            }
-            return networkResponse;
-          })
-          .catch(() => cachedResponse);
-        return cachedResponse || fetchPromise;
-      })
-    )
-  );
-});
+  self.addEventListener('activate', event => {
+    event.waitUntil(
+      caches.keys().then(keys => Promise.all(
+        keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))
+      ))
+    );
+  });
+
+  self.addEventListener('fetch', event => {
+    event.respondWith(handleFetch(event.request));
+  });
+}

--- a/tests/service-worker.test.js
+++ b/tests/service-worker.test.js
@@ -1,0 +1,31 @@
+import { jest } from '@jest/globals';
+import { bumpCacheVersion, handleFetch, OFFLINE_URL } from '../service-worker.js';
+
+describe('service worker', () => {
+  test('bumpCacheVersion increments numeric suffix', () => {
+    expect(bumpCacheVersion('v1')).toBe('v2');
+    expect(bumpCacheVersion('v9')).toBe('v10');
+  });
+
+  test('returns offline page when network fails and cache empty', async () => {
+    const store = new Map();
+    const mockCache = {
+      match: jest.fn(req => Promise.resolve(store.get(req.url || req))),
+      put: jest.fn((req, res) => {
+        store.set(req.url || req, res);
+        return Promise.resolve();
+      }),
+      keys: jest.fn(() => Promise.resolve([])),
+      delete: jest.fn(() => Promise.resolve(true))
+    };
+    global.caches = {
+      open: jest.fn(() => Promise.resolve(mockCache)),
+      match: jest.fn(key => Promise.resolve(store.get(key)))
+    };
+    store.set(OFFLINE_URL, new Response('offline', { status: 200 }));
+    global.fetch = jest.fn().mockRejectedValue(new Error('network fail'));
+    const response = await handleFetch(new Request('https://example.com/data'));
+    const text = await response.text();
+    expect(text).toBe('offline');
+  });
+});


### PR DESCRIPTION
## Summary
- add helper to bump cache version and include offline fallback response
- cache offline page and handle network failures gracefully
- test cache version bumping and offline fallback behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b965dc05b4832ab31fc5a2e33735a8