### PR TITLE
Add tests for school education progression

### DIFF
--- a/tests/school.test.js
+++ b/tests/school.test.js
@@ -1,0 +1,111 @@
+import { jest } from '@jest/globals';
+
+const localStorageMock = (() => {
+  let store = {};
+  return {
+    getItem(key) {
+      return store[key] || null;
+    },
+    setItem(key, value) {
+      store[key] = value.toString();
+    },
+    removeItem(key) {
+      delete store[key];
+    },
+    clear() {
+      store = {};
+    }
+  };
+})();
+
+Object.defineProperty(global, 'localStorage', { value: localStorageMock });
+
+global.window = { addEventListener: jest.fn() };
+
+jest.unstable_mockModule('../windowManager.js', () => ({
+  refreshOpenWindows: jest.fn(),
+  openWindow: jest.fn(),
+  closeWindow: jest.fn()
+}));
+
+jest.unstable_mockModule('../endscreen.js', () => ({
+  showEndScreen: jest.fn(),
+  hideEndScreen: jest.fn()
+}));
+
+jest.unstable_mockModule('../realestate.js', () => ({
+  initBrokers: jest.fn()
+}));
+
+const school = await import('../school.js');
+const state = await import('../state.js');
+const { advanceSchool, dropOut, reEnrollHighSchool, getGed } = school;
+const { game } = state;
+
+beforeEach(() => {
+  game.age = 0;
+  game.log.length = 0;
+  Object.assign(game.education, {
+    current: null,
+    highest: 'none',
+    progress: 0,
+    droppedOut: false,
+    major: null
+  });
+});
+
+describe('advanceSchool', () => {
+  test('starts elementary school and logs entry', () => {
+    game.age = 5;
+    advanceSchool();
+    expect(game.education.current).toBe('elementary');
+    expect(game.education.progress).toBe(1);
+    expect(game.education.highest).toBe('none');
+    expect(game.log[0].text).toBe('You started Elementary School.');
+  });
+
+  test('completes elementary school and resets progress', () => {
+    game.education.current = 'elementary';
+    game.education.progress = 5;
+    advanceSchool();
+    expect(game.education.highest).toBe('elementary');
+    expect(game.education.current).toBeNull();
+    expect(game.education.progress).toBe(0);
+    expect(game.log[0].text).toBe('You finished Elementary School.');
+  });
+});
+
+describe('dropOut', () => {
+  test('drops out of high school and logs entry', () => {
+    game.age = 16;
+    game.education.current = 'high';
+    dropOut();
+    expect(game.education.current).toBeNull();
+    expect(game.education.droppedOut).toBe(true);
+    expect(game.log[0].text).toBe('You dropped out of high school.');
+  });
+});
+
+describe('reEnrollHighSchool', () => {
+  test('re-enrolls and resets progress', () => {
+    game.education.droppedOut = true;
+    game.education.highest = 'trade';
+    reEnrollHighSchool();
+    expect(game.education.droppedOut).toBe(false);
+    expect(game.education.current).toBe('high');
+    expect(game.education.progress).toBe(0);
+    expect(game.log[0].text).toBe('You started High School.');
+  });
+});
+
+describe('getGed', () => {
+  test('awards GED, resets progress and logs entry', () => {
+    game.education.highest = 'middle';
+    getGed();
+    expect(game.education.highest).toBe('high');
+    expect(game.education.current).toBeNull();
+    expect(game.education.progress).toBe(0);
+    expect(game.education.droppedOut).toBe(false);
+    expect(game.log[0].text).toBe('You obtained a GED.');
+  });
+});


### PR DESCRIPTION
## Summary
- add comprehensive unit tests for school progression scenarios
- verify dropout, re-enrollment, and GED paths reset progress and log events

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b965b335c0832aa8c8e28ea4c4269b