### PR TITLE
Add job performance tests for good and bad activities

### DIFF
--- a/tests/jobs.performance.test.js
+++ b/tests/jobs.performance.test.js
@@ -1,0 +1,51 @@
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('../windowManager.js', () => ({
+  refreshOpenWindows: jest.fn()
+}));
+
+jest.unstable_mockModule('../endscreen.js', () => ({
+  showEndScreen: jest.fn(),
+  hideEndScreen: jest.fn()
+}));
+
+jest.unstable_mockModule('../realestate.js', () => ({
+  initBrokers: jest.fn()
+}));
+
+global.window = { addEventListener: jest.fn() };
+const { game } = await import('../state.js');
+const { adjustJobPerformance } = await import('../jobs.js');
+
+beforeEach(() => {
+  game.job = { title: 'Tester', salary: 0 };
+  game.jobPerformance = 50;
+  game.log = [];
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('adjustJobPerformance', () => {
+  test('increases performance for good activities', () => {
+    jest
+      .spyOn(Math, 'random')
+      .mockReturnValueOnce(0.5)
+      .mockReturnValueOnce(0.9);
+    adjustJobPerformance('good');
+    expect(game.jobPerformance).toBe(53);
+    expect(game.log[0].text).toBe('You impressed your boss. (+Performance)');
+  });
+
+  test('decreases performance for bad activities', () => {
+    jest
+      .spyOn(Math, 'random')
+      .mockReturnValueOnce(0.5)
+      .mockReturnValueOnce(0.9);
+    adjustJobPerformance('bad');
+    expect(game.jobPerformance).toBe(47);
+    expect(game.log[0].text).toBe('You slacked off at work. (-Performance)');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add Jest tests simulating good and bad activities on job performance
- verify performance increases or decreases and proper log messages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b965b7267c832aba85fd7bde4947cb