### PR TITLE
test: cover localStorage failure in storageAvailable

### DIFF
--- a/tests/state.storage.test.js
+++ b/tests/state.storage.test.js
@@ -1,0 +1,52 @@
+import { jest } from '@jest/globals';
+
+const originalWindow = globalThis.window;
+globalThis.window = { addEventListener: () => {} };
+
+afterAll(() => {
+  globalThis.window = originalWindow;
+});
+
+await jest.unstable_mockModule('../endscreen.js', () => ({
+  showEndScreen: () => {},
+  hideEndScreen: () => {}
+}));
+
+await jest.unstable_mockModule('../windowManager.js', () => ({
+  refreshOpenWindows: () => {}
+}));
+
+await jest.unstable_mockModule('../realestate.js', () => ({
+  initBrokers: () => {}
+}));
+
+const { storageAvailable } = await import('../state.js');
+
+describe('storageAvailable', () => {
+  const original = globalThis.localStorage;
+
+  afterEach(() => {
+    globalThis.localStorage = original;
+  });
+
+  test('returns false when setItem throws', () => {
+    globalThis.localStorage = {
+      setItem() {
+        throw new Error('fail');
+      },
+      removeItem() {}
+    };
+    expect(storageAvailable()).toBe(false);
+  });
+
+  test('returns false when removeItem throws', () => {
+    globalThis.localStorage = {
+      setItem() {},
+      removeItem() {
+        throw new Error('fail');
+      }
+    };
+    expect(storageAvailable()).toBe(false);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for storageAvailable to ensure false is returned when localStorage.setItem or removeItem throw
- mock DOM-dependent modules to run in Node

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b965c42b28832aa7fca9bfb4a764c1