### PR TITLE
Handle network failures when loading house categories

### DIFF
--- a/realestate.js
+++ b/realestate.js
@@ -91,13 +91,18 @@ function pickIcon(name) {
   return defaultIcon;
 }
 
-async function loadHouseCategories() {
+export async function loadHouseCategories() {
   if (houseCategories.length) return houseCategories;
-  const res = await fetch('./activities/data/houseCategories.json');
-  houseCategories = await res.json();
-  houseCategories.forEach(c => {
-    c.icon = pickIcon(c.type);
-  });
+  try {
+    const res = await fetch('./activities/data/houseCategories.json');
+    houseCategories = await res.json();
+    houseCategories.forEach(c => {
+      c.icon = pickIcon(c.type);
+    });
+  } catch (err) {
+    console.error('Failed to load house categories', err);
+    houseCategories = [];
+  }
   return houseCategories;
 }
 

--- a/tests/realestate.test.js
+++ b/tests/realestate.test.js
@@ -1,0 +1,29 @@
+import { jest } from '@jest/globals';
+
+describe('loadHouseCategories', () => {
+  test('returns empty array on fetch failure', async () => {
+    const originalFetch = global.fetch;
+    global.fetch = jest.fn().mockRejectedValue(new Error('Network error'));
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.unstable_mockModule('../state.js', () => ({
+      game: {},
+      addLog: jest.fn(),
+      saveGame: jest.fn(),
+      unlockAchievement: jest.fn()
+    }));
+    jest.unstable_mockModule('../utils.js', () => ({
+      rand: jest.fn(),
+      clamp: jest.fn()
+    }));
+    jest.unstable_mockModule('../nameGenerator.js', () => ({
+      faker: { person: { firstName: jest.fn(), lastName: jest.fn() } }
+    }));
+    const { loadHouseCategories } = await import('../realestate.js');
+    const result = await loadHouseCategories();
+    expect(result).toEqual([]);
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+    global.fetch = originalFetch;
+  });
+});
+


### PR DESCRIPTION
## Summary
- Guard house category fetching with try/catch, logging failures and returning an empty array
- Add unit test to ensure empty array fallback when network request fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b965c6eea0832ab72667a4457bd485