### PR TITLE
refactor: centralize faker utility

### DIFF
--- a/activities/adoption.js
+++ b/activities/adoption.js
@@ -1,6 +1,8 @@
 import { game, addLog, applyAndSave } from '../state.js';
 import { openWindow } from '../windowManager.js';
-import { faker } from 'https://cdn.jsdelivr.net/npm/@faker-js/faker@8.3.1/+esm';
+import { getFaker } from '../utils/faker.js';
+
+const faker = await getFaker();
 
 export { openWindow };
 

--- a/activities/emigrate.js
+++ b/activities/emigrate.js
@@ -1,6 +1,8 @@
 import { game, addLog, applyAndSave } from '../state.js';
 import { clamp, rand } from '../utils.js';
-import { faker } from 'https://cdn.jsdelivr.net/npm/@faker-js/faker@8.3.1/+esm';
+import { getFaker } from '../utils/faker.js';
+
+const faker = await getFaker();
 
 export function renderEmigrate(container) {
   const head = document.createElement('div');

--- a/activities/fertility.js
+++ b/activities/fertility.js
@@ -1,5 +1,7 @@
 import { game, addLog, applyAndSave } from '../state.js';
-import { faker } from 'https://cdn.jsdelivr.net/npm/@faker-js/faker@8.3.1/+esm';
+import { getFaker } from '../utils/faker.js';
+
+const faker = await getFaker();
 
 const TREATMENTS = [
   { label: 'Intrauterine Insemination', cost: 3000, success: 0.25 },

--- a/activities/identity.js
+++ b/activities/identity.js
@@ -1,6 +1,8 @@
 import { game, addLog, applyAndSave } from '../state.js';
 import { rand, clamp } from '../utils.js';
-import { faker } from 'https://cdn.jsdelivr.net/npm/@faker-js/faker@8.3.1/+esm';
+import { getFaker } from '../utils/faker.js';
+
+const faker = await getFaker();
 
 export function renderIdentity(container) {
   const wrap = document.createElement('div');

--- a/activities/love.js
+++ b/activities/love.js
@@ -1,17 +1,8 @@
 import { game, addLog, applyAndSave } from '../state.js';
 import { rand, clamp } from '../utils.js';
-import { faker as fallbackFaker } from '../nameGenerator.js';
+import { getFaker } from '../utils/faker.js';
 
-let faker = fallbackFaker;
-
-(async () => {
-  try {
-    const mod = await import('https://cdn.jsdelivr.net/npm/@faker-js/faker@8.3.1/+esm');
-    faker = mod.faker;
-  } catch (err) {
-    console.warn('Faker CDN import failed, using internal generator', err);
-  }
-})();
+const faker = await getFaker();
 
 export function renderLove(container) {
   const wrap = document.createElement('div');

--- a/realestate.js
+++ b/realestate.js
@@ -1,17 +1,8 @@
 import { game, addLog, saveGame, unlockAchievement } from './state.js';
 import { rand, clamp } from './utils.js';
-import { faker as fallbackFaker } from './nameGenerator.js';
+import { getFaker } from './utils/faker.js';
 
-let faker = fallbackFaker;
-
-(async () => {
-  try {
-    const mod = await import('https://cdn.jsdelivr.net/npm/@faker-js/faker@8.3.1/+esm');
-    faker = mod.faker;
-  } catch (err) {
-    console.warn('Faker CDN import failed, using internal generator', err);
-  }
-})();
+const faker = await getFaker();
 
 // house categories loaded from external data
 let houseCategories = [];

--- a/state.js
+++ b/state.js
@@ -1,19 +1,10 @@
 import { refreshOpenWindows } from './windowManager.js';
 import { rand } from './utils.js';
 import { showEndScreen, hideEndScreen } from './endscreen.js';
-import { faker as fallbackFaker } from './nameGenerator.js';
 import { initBrokers } from './realestate.js';
+import { getFaker } from './utils/faker.js';
 
-let faker = fallbackFaker;
-
-(async () => {
-  try {
-    const mod = await import('https://cdn.jsdelivr.net/npm/@faker-js/faker@8.3.1/+esm');
-    faker = mod.faker;
-  } catch (err) {
-    console.warn('Faker CDN import failed, using internal generator', err);
-  }
-})();
+const faker = await getFaker();
 
 export function storageAvailable() {
   try {

--- a/tests/state.test.js
+++ b/tests/state.test.js
@@ -1,0 +1,38 @@
+import { jest } from '@jest/globals';
+
+const mockFaker = {
+  person: {
+    firstName: () => 'Test',
+    lastName: () => 'User'
+  },
+  location: {
+    city: () => 'Townsville',
+    country: () => 'Neverland'
+  }
+};
+
+jest.unstable_mockModule('../utils/faker.js', () => ({
+  getFaker: jest.fn(async () => mockFaker)
+}));
+jest.unstable_mockModule('../realestate.js', () => ({
+  initBrokers: () => {}
+}));
+
+global.document = { getElementById: () => null };
+global.window = { addEventListener: () => {} };
+
+const { game, addLog } = await import('../state.js');
+const { getFaker } = await import('../utils/faker.js');
+
+describe('addLog', () => {
+  test('appends log entries', () => {
+    const initial = game.log.length;
+    addLog('hello');
+    expect(game.log.length).toBe(initial + 1);
+  });
+});
+
+test('getFaker was called', () => {
+  expect(getFaker).toHaveBeenCalled();
+});
+

--- a/utils/faker.js
+++ b/utils/faker.js
@@ -1,0 +1,15 @@
+let cached;
+
+export async function getFaker() {
+  if (cached) return cached;
+  try {
+    const mod = await import('https://cdn.jsdelivr.net/npm/@faker-js/faker@8.3.1/+esm');
+    cached = mod.faker;
+  } catch (err) {
+    console.warn('Faker CDN import failed, using internal generator', err);
+    const { faker } = await import('../nameGenerator.js');
+    cached = faker;
+  }
+  return cached;
+}
+


### PR DESCRIPTION
## Summary
- add `utils/faker.js` with cached async `getFaker`
- use `getFaker` across state, real estate, and activity modules
- mock `getFaker` in tests to avoid network

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b965c96db8832a95316ce9afb54a18