### PR TITLE
refactor: centralize message arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,7 @@ Open `index.html` in any modern web browser to play. No build tools or server ar
 ## Development Notes
 - Avoid browser popups. Use in-game tabs or windows for confirmations.
 
+## Messages
+Reusable log message variations are stored in the `messages/` directory. Each module exports arrays or helper functions that return
+message arrays. Game scripts import these helpers to keep action files concise and to share common messages.
+

--- a/actions.js
+++ b/actions.js
@@ -5,6 +5,7 @@ import { tickRelationships } from './activities/love.js';
 import { tickRealEstate } from './realestate.js';
 import { advanceSchool, accrueStudentLoanInterest } from './school.js';
 import { tickJob, adjustJobPerformance } from './jobs.js';
+import * as msg from './messages/actionMessages.js';
 
 const promotionThresholds = { entry: 3, mid: 5 };
 const promotionOrder = { entry: 'mid', mid: 'senior' };
@@ -25,132 +26,63 @@ function paySalary() {
     }
     game.money += earned;
     game.job.experience = (game.job.experience || 0) + (game.job.expMultiplier || 1);
-    addLog([
-      `You worked as a ${game.job.title} and earned $${earned.toLocaleString()}.`,
-      `Your job as a ${game.job.title} paid $${earned.toLocaleString()}.`,
-      `Working as a ${game.job.title} brought in $${earned.toLocaleString()}.`,
-      `As a ${game.job.title}, you earned $${earned.toLocaleString()}.`,
-      `You pulled in $${earned.toLocaleString()} from your ${game.job.title} job.`
-    ], 'job');
+      addLog(
+        msg.paySalaryMessages(game.job.title, earned),
+        'job'
+      );
   }
 }
 
 function randomEvent() {
   if (game.age === 5) {
-    addLog([
-      'You learned to read and write. (+Smarts)',
-      'Reading and writing finally clicked for you. (+Smarts)',
-      'Letters and words make sense now—you can read and write. (+Smarts)',
-      'You grasped literacy and your mind grew sharper. (+Smarts)',
-      'The world of words opened up to you. (+Smarts)'
-    ], 'education');
+    addLog(msg.age5LiteracyMessages, 'education');
     game.smarts = clamp(game.smarts + rand(2, 5));
   }
   if (game.age === 12) {
-    addLog([
-      'You discovered video games. (+Happiness, -Looks?)',
-      'Video games entered your life and brought you joy. (+Happiness, -Looks?)',
-      'You found the world of gaming. (+Happiness, -Looks?)',
-      'Pixels and fun: you started playing video games. (+Happiness, -Looks?)',
-      'A new hobby emerged—video games! (+Happiness, -Looks?)'
-    ], 'hobby');
+    addLog(msg.age12VideoGameMessages, 'hobby');
     game.happiness = clamp(game.happiness + 4);
     game.looks = clamp(game.looks - 1);
   }
   if (game.age === 16) {
-    addLog([
-      'You can start looking for a part-time job.',
-      'It\'s time to search for a part-time job.',
-      'A part-time job is now within reach.',
-      'You\'re old enough for part-time work.',
-      'Start hunting for a part-time job.'
-    ], 'job');
+    addLog(msg.age16PartTimeJobMessages, 'job');
   }
   if (game.age === 25) {
     const rent = Math.min(2000, game.money);
     game.money -= rent;
     game.happiness = clamp(game.happiness + 2);
-    addLog([
-      'You moved into your own place. (-Money, +Happiness)',
-      'A place of your own—costly but satisfying. (-Money, +Happiness)',
-      'Independence! You got your own place. (-Money, +Happiness)',
-      'You settled into a solo home. (-Money, +Happiness)',
-      'Your own pad brings joy but drains cash. (-Money, +Happiness)'
-    ]);
+    addLog(msg.age25OwnPlaceMessages);
   }
   if (game.age === 30) {
     game.smarts = clamp(game.smarts + rand(1, 3));
-    addLog([
-      'You reflected on life and grew wiser. (+Smarts)',
-      'Deep thoughts made you wiser. (+Smarts)',
-      'Life reflection boosted your wisdom. (+Smarts)',
-      'Contemplation sharpened your mind. (+Smarts)',
-      'Thinking back on life, you gained insight. (+Smarts)'
-    ]);
+    addLog(msg.age30ReflectionMessages);
   }
   if (game.age === 40) {
     const cost = Math.min(5000, game.money);
     game.money -= cost;
     game.happiness = clamp(game.happiness + 3);
-    addLog([
-      'A midlife splurge lifted your spirits. (-Money, +Happiness)',
-      'You treated yourself midlife and felt better. (-Money, +Happiness)',
-      'A costly indulgence brightened your mood. (-Money, +Happiness)',
-      'Retail therapy worked wonders midlife. (-Money, +Happiness)',
-      'You spent freely and cheered up. (-Money, +Happiness)'
-    ]);
+    addLog(msg.age40SplurgeMessages);
   }
   if (!game.sick && rand(1, 100) <= 8) {
     game.sick = true;
-    addLog([
-      'You caught a nasty flu. (See Doctor)',
-      'A rough flu has you down. (See Doctor)',
-      'You\'re sick with the flu. (See Doctor)',
-      'Flu symptoms hit you hard. (See Doctor)',
-      'You came down with the flu. (See Doctor)'
-    ], 'health');
+    addLog(msg.fluMessages, 'health');
   }
   if (game.age > 50 && rand(1, 100) <= game.age - 45) {
-    addLog([
-      'Aches and pains are catching up with you. (-Health)',
-      'Your body aches more these days. (-Health)',
-      'Nagging pains remind you of age. (-Health)',
-      'Soreness creeps in as time passes. (-Health)',
-      'Health is waning; aches are frequent. (-Health)'
-    ], 'health');
+    addLog(msg.age50HealthDeclineMessages, 'health');
     game.health = clamp(game.health - rand(2, 6));
   }
   if (rand(1, 200) === 1) {
     const found = rand(20, 200);
     game.money += found;
-    addLog([
-      `You found a wallet with $${found.toLocaleString()} inside. (+Money)`,
-      `A wallet on the ground held $${found.toLocaleString()}. (+Money)`,
-      `Lucky find! $${found.toLocaleString()} was in a wallet you spotted. (+Money)`,
-      `You stumbled upon $${found.toLocaleString()} in a discarded wallet. (+Money)`,
-      `Someone\'s lost wallet gave you $${found.toLocaleString()}. (+Money)`
-    ]);
+    addLog(msg.foundWalletMessages(found));
   }
   if (rand(1, 250) === 1 && game.money > 0) {
     const lost = Math.min(game.money, rand(10, 300));
     game.money -= lost;
-    addLog([
-      `You lost your wallet. (-$${lost.toLocaleString()})`,
-      `Your wallet went missing. (-$${lost.toLocaleString()})`,
-      `Misplaced wallet cost you $${lost.toLocaleString()}.`,
-      `You couldn\'t find your wallet and $${lost.toLocaleString()} vanished.`,
-      `Losing your wallet set you back $${lost.toLocaleString()}.`
-    ]);
+    addLog(msg.lostWalletMessages(lost));
   }
   if (rand(1, 300) === 1) {
     game.smarts = clamp(game.smarts + rand(2, 4));
-    addLog([
-      'A chance encounter taught you something new. (+Smarts)',
-      'You learned something from a random meeting. (+Smarts)',
-      'An unexpected meeting boosted your knowledge. (+Smarts)',
-      'A random interaction broadened your mind. (+Smarts)',
-      'Serendipity struck, and you learned. (+Smarts)'
-    ]);
+    addLog(msg.chanceLearningMessages);
   }
   if (rand(1, 1000) === 1) {
     die('A tragic accident ended your life.');
@@ -175,13 +107,7 @@ function tickEconomy() {
  */
 export function ageUp() {
   if (!game.alive) {
-    addLog([
-      'You are no longer alive. Start a new life.',
-      'Your life has ended. Begin anew.',
-      'You\'ve passed away. A fresh start awaits.',
-      'Death has come. Start over.',
-      'Your journey ended. Try a new life.'
-    ], 'life');
+    addLog(msg.alreadyDeadMessages, 'life');
     saveGame();
     return;
   }
@@ -222,13 +148,7 @@ export function ageUp() {
     }
     if (game.age >= game.maxAge) {
       game.alive = false;
-      addLog([
-        'You died of old age.',
-        'Old age finally claimed you.',
-        'Your time came due to old age.',
-        'Age caught up; you passed away.',
-        'Life ended peacefully in old age.'
-      ], 'life');
+      addLog(msg.oldAgeDeathMessages, 'life');
     }
     if (game.health <= 0 && game.alive) {
       game.alive = false;
@@ -247,25 +167,13 @@ export function study() {
   if (!game.alive) return;
   applyAndSave(() => {
     if (game.inJail) {
-      addLog([
-        'You studied in jail. (+Smarts)',
-        'Behind bars, you hit the books. (+Smarts)',
-        'Jail time turned into study time. (+Smarts)',
-        'You cracked open books in your cell. (+Smarts)',
-        'Learning continued even in jail. (+Smarts)'
-      ], 'education');
+      addLog(msg.studyInJailMessages, 'education');
     }
     const gain = rand(2, 4);
     const mood = rand(-1, 1);
     game.smarts = clamp(game.smarts + gain);
     game.happiness = clamp(game.happiness + mood);
-    addLog([
-      `You studied hard. +${gain} Smarts${mood < 0 ? ` • ${mood} Happiness` : ''}.`,
-      `Hours of study earned you +${gain} Smarts${mood < 0 ? ` • ${mood} Happiness` : ''}.`,
-      `Focused studying gave you +${gain} Smarts${mood < 0 ? ` • ${mood} Happiness` : ''}.`,
-      `You hit the books for +${gain} Smarts${mood < 0 ? ` • ${mood} Happiness` : ''}.`,
-      `Diligent study boosted you by +${gain} Smarts${mood < 0 ? ` • ${mood} Happiness` : ''}.`
-    ], 'education');
+    addLog(msg.studyResultMessages(gain, mood), 'education');
   });
 }
 
@@ -280,13 +188,7 @@ export function meditate() {
     const smart = rand(1, 2);
     game.happiness = clamp(game.happiness + happy);
     game.smarts = clamp(game.smarts + smart);
-    addLog([
-      `You meditated. +${happy} Happiness, +${smart} Smarts.`,
-      `Meditation brought +${happy} Happiness and +${smart} Smarts.`,
-      `Quiet reflection added +${happy} Happiness and +${smart} Smarts.`,
-      `You found peace: +${happy} Happiness, +${smart} Smarts.`,
-      `Mindfulness rewarded you with +${happy} Happiness and +${smart} Smarts.`
-    ]);
+    addLog(msg.meditateMessages(happy, smart));
   });
 }
 
@@ -296,24 +198,12 @@ export function meditate() {
  */
 export function workExtra() {
   if (!game.job) {
-    addLog([
-      'You need a job first.',
-      'Employment comes before overtime.',
-      'Find a job before trying that.',
-      'No job, no overtime.',
-      'Secure work before attempting this.'
-    ], 'job');
+    addLog(msg.workExtraNoJobMessages, 'job');
     saveGame();
     return;
   }
   if (game.inJail) {
-    addLog([
-      'You cannot work extra while in jail.',
-      'Jail time means no extra work.',
-      'Behind bars, overtime is impossible.',
-      'No overtime from a cell.',
-      'You\'re locked up—no extra shifts.'
-    ], 'job');
+    addLog(msg.workExtraJailMessages, 'job');
     saveGame();
     return;
   }
@@ -322,13 +212,7 @@ export function workExtra() {
     game.money += bonus;
     game.happiness = clamp(game.happiness - rand(0, 2));
     game.health = clamp(game.health - rand(0, 2));
-    addLog([
-      `You took overtime. Earned $${bonus.toLocaleString()}. (-Small Health/Happiness)`,
-      `Extra hours paid $${bonus.toLocaleString()}. (-Small Health/Happiness)`,
-      `Overtime brought in $${bonus.toLocaleString()}. (-Small Health/Happiness)`,
-      `You grabbed overtime for $${bonus.toLocaleString()}. (-Small Health/Happiness)`,
-      `Working extra netted $${bonus.toLocaleString()}. (-Small Health/Happiness)`
-    ], 'job');
+    addLog(msg.workExtraResultMessages(bonus), 'job');
   });
 }
 
@@ -341,25 +225,13 @@ export function hitGym() {
     applyAndSave(() => {
       game.health = clamp(game.health + rand(2, 5));
       game.happiness = clamp(game.happiness + rand(1, 3));
-      addLog([
-        'You worked out in the yard. (+Health, +Happiness)',
-        'Yard exercise boosted your stats. (+Health, +Happiness)',
-        'You hit the yard for a workout. (+Health, +Happiness)',
-        'Prison yard training helped you. (+Health, +Happiness)',
-        'Outdoor reps in the yard lifted you. (+Health, +Happiness)'
-      ], 'health');
+      addLog(msg.hitGymJailMessages, 'health');
     });
     return;
   }
   const cost = 20;
   if (game.money < cost) {
-    addLog([
-      'Not enough money for the gym ($20).',
-      'You can\'t afford the $20 gym fee.',
-      'Cash shortage keeps you from the gym.',
-      'No $20, no gym visit.',
-      'Your wallet is too light for the gym.'
-    ], 'health');
+    addLog(msg.hitGymNoMoneyMessages, 'health');
     saveGame();
     return;
   }
@@ -367,13 +239,7 @@ export function hitGym() {
     game.money -= cost;
     game.health = clamp(game.health + rand(2, 5));
     game.happiness = clamp(game.happiness + rand(1, 3));
-    addLog([
-      'You hit the gym. (+Health, +Happiness)',
-      'Gym time improved you. (+Health, +Happiness)',
-      'A gym session boosted your stats. (+Health, +Happiness)',
-      'You exercised at the gym. (+Health, +Happiness)',
-      'Workout complete—feeling better. (+Health, +Happiness)'
-    ], 'health');
+    addLog(msg.hitGymMessages, 'health');
   });
 }
 
@@ -383,25 +249,13 @@ export function hitGym() {
  */
 export function seeDoctor() {
   if (game.inJail) {
-    addLog([
-      'No access to a doctor here.',
-      'You can\'t see a doctor from jail.',
-      'Medical help isn\'t available here.',
-      'No doctors are reachable right now.',
-      'This place lacks medical care.'
-    ], 'health');
+    addLog(msg.doctorJailMessages, 'health');
     saveGame();
     return;
   }
   const cost = game.sick ? 120 : 60;
   if (game.money < cost) {
-    addLog([
-      `Doctor visit costs $${cost}. Not enough money.`,
-      `A doctor visit is $${cost}—you can\'t afford it.`,
-      `No $${cost} for the doctor.`,
-      `Funds are short for a $${cost} doctor visit.`,
-      `You need $${cost} to see the doctor.`
-    ], 'health');
+    addLog(msg.doctorNoMoneyMessages(cost), 'health');
     saveGame();
     return;
   }
@@ -410,22 +264,10 @@ export function seeDoctor() {
     if (game.sick) {
       game.sick = false;
       game.health = clamp(game.health + rand(6, 12));
-      addLog([
-        'The doctor treated your illness. (+Health)',
-        'Medical care cured your illness. (+Health)',
-        'The doctor\'s treatment healed you. (+Health)',
-        'Care from the doctor restored you. (+Health)',
-        'A doctor visit wiped out your illness. (+Health)'
-      ], 'health');
+      addLog(msg.doctorHealedMessages, 'health');
     } else {
       game.health = clamp(game.health + rand(2, 6));
-      addLog([
-        'Routine check-up made you feel better. (+Health)',
-        'A simple check-up boosted your health. (+Health)',
-        'The doctor\'s exam refreshed you. (+Health)',
-        'You felt better after a routine check. (+Health)',
-        'A check-up improved your health. (+Health)'
-      ], 'health');
+      addLog(msg.doctorCheckupMessages, 'health');
     }
   });
 }
@@ -436,13 +278,7 @@ export function seeDoctor() {
  */
 export function crime() {
   if (game.inJail) {
-    addLog([
-      'You are already in jail.',
-      'You\'re currently jailed.',
-      'Locked up already, you can\'t do that.',
-      'You\'re already behind bars.',
-      'No need for more crime; you\'re in jail.'
-    ], 'crime');
+    addLog(msg.crimeJailMessages, 'crime');
     saveGame();
     return;
   }
@@ -459,34 +295,16 @@ export function crime() {
       const amount = rand(c.reward[0], c.reward[1]);
       game.money += amount;
       game.happiness = clamp(game.happiness + rand(0, 2));
-      addLog([
-        `Crime succeeded: ${c.name}. You gained $${amount.toLocaleString()}.`,
-        `${c.name} went smoothly—you got $${amount.toLocaleString()}.`,
-        `Success! ${c.name} netted you $${amount.toLocaleString()}.`,
-        `Your ${c.name} paid off with $${amount.toLocaleString()}.`,
-        `${c.name} worked and earned you $${amount.toLocaleString()}.`
-      ], 'crime');
+      addLog(msg.crimeSuccessMessages(c.name, amount), 'crime');
     } else {
       if (rand(1, 100) <= 75) {
         game.inJail = true;
         game.jailYears = rand(1, 4);
-        addLog([
-          `Busted doing ${c.name}. You were jailed for ${game.jailYears} year(s).`,
-          `Caught in the act of ${c.name}; ${game.jailYears} year(s) in jail.`,
-          `${c.name} failed and landed you ${game.jailYears} year(s) in jail.`,
-          `Authorities nabbed you for ${c.name}; ${game.jailYears} year(s) behind bars.`,
-          `Your ${c.name} attempt backfired—${game.jailYears} year(s) in jail.`
-        ], 'crime');
+        addLog(msg.crimeCaughtMessages(c.name, game.jailYears), 'crime');
       } else {
         const dmg = rand(4, 15);
         game.health = clamp(game.health - dmg);
-        addLog([
-          `Crime failed: ${c.name}. You were injured (-${dmg} Health).`,
-          `${c.name} went wrong and you took damage (-${dmg} Health).`,
-          `Failure at ${c.name} left you hurt (-${dmg} Health).`,
-          `Injury followed a botched ${c.name} (-${dmg} Health).`,
-          `Attempting ${c.name} caused harm (-${dmg} Health).`
-        ], 'crime');
+        addLog(msg.crimeInjuryMessages(c.name, dmg), 'crime');
         if (game.health <= 0) {
           die('You died from your injuries.');
         }

--- a/jail.js
+++ b/jail.js
@@ -1,4 +1,5 @@
 import { game, addLog, saveGame } from './state.js';
+import { releaseMessages } from './messages/jailMessages.js';
 
 export function tickJail() {
   if (!game.inJail) return;
@@ -7,13 +8,7 @@ export function tickJail() {
   if (game.jailYears <= 0) {
     game.inJail = false;
     delete game.jailYears;
-    addLog([
-      'You were released from jail.',
-      'Freedom at last—you left jail.',
-      'Your jail time ended and you walked free.',
-      'The prison gates opened; you\'re out.',
-      'You served your sentence and were released.'
-    ], 'crime');
+    addLog(releaseMessages, 'crime');
   }
   saveGame();
 }

--- a/messages/actionMessages.js
+++ b/messages/actionMessages.js
@@ -1,0 +1,267 @@
+export function paySalaryMessages(jobTitle, earned) {
+  return [
+    `You worked as a ${jobTitle} and earned $${earned.toLocaleString()}.`,
+    `Your job as a ${jobTitle} paid $${earned.toLocaleString()}.`,
+    `Working as a ${jobTitle} brought in $${earned.toLocaleString()}.`,
+    `As a ${jobTitle}, you earned $${earned.toLocaleString()}.`,
+    `You pulled in $${earned.toLocaleString()} from your ${jobTitle} job.`
+  ];
+}
+
+export const age5LiteracyMessages = [
+  'You learned to read and write. (+Smarts)',
+  'Reading and writing finally clicked for you. (+Smarts)',
+  'Letters and words make sense now—you can read and write. (+Smarts)',
+  'You grasped literacy and your mind grew sharper. (+Smarts)',
+  'The world of words opened up to you. (+Smarts)'
+];
+
+export const age12VideoGameMessages = [
+  'You discovered video games. (+Happiness, -Looks?)',
+  'Video games entered your life and brought you joy. (+Happiness, -Looks?)',
+  'You found the world of gaming. (+Happiness, -Looks?)',
+  'Pixels and fun: you started playing video games. (+Happiness, -Looks?)',
+  'A new hobby emerged—video games! (+Happiness, -Looks?)'
+];
+
+export const age16PartTimeJobMessages = [
+  'You can start looking for a part-time job.',
+  "It's time to search for a part-time job.",
+  'A part-time job is now within reach.',
+  "You're old enough for part-time work.",
+  'Start hunting for a part-time job.'
+];
+
+export const age25OwnPlaceMessages = [
+  'You moved into your own place. (-Money, +Happiness)',
+  'A place of your own—costly but satisfying. (-Money, +Happiness)',
+  'Independence! You got your own place. (-Money, +Happiness)',
+  'You settled into a solo home. (-Money, +Happiness)',
+  'Your own pad brings joy but drains cash. (-Money, +Happiness)'
+];
+
+export const age30ReflectionMessages = [
+  'You reflected on life and grew wiser. (+Smarts)',
+  'Deep thoughts made you wiser. (+Smarts)',
+  'Life reflection boosted your wisdom. (+Smarts)',
+  'Contemplation sharpened your mind. (+Smarts)',
+  'Thinking back on life, you gained insight. (+Smarts)'
+];
+
+export const age40SplurgeMessages = [
+  'A midlife splurge lifted your spirits. (-Money, +Happiness)',
+  'You treated yourself midlife and felt better. (-Money, +Happiness)',
+  'A costly indulgence brightened your mood. (-Money, +Happiness)',
+  'Retail therapy worked wonders midlife. (-Money, +Happiness)',
+  'You spent freely and cheered up. (-Money, +Happiness)'
+];
+
+export const fluMessages = [
+  'You caught a nasty flu. (See Doctor)',
+  'A rough flu has you down. (See Doctor)',
+  "You're sick with the flu. (See Doctor)",
+  'Flu symptoms hit you hard. (See Doctor)',
+  'You came down with the flu. (See Doctor)'
+];
+
+export const age50HealthDeclineMessages = [
+  'Aches and pains are catching up with you. (-Health)',
+  'Your body aches more these days. (-Health)',
+  'Nagging pains remind you of age. (-Health)',
+  'Soreness creeps in as time passes. (-Health)',
+  'Health is waning; aches are frequent. (-Health)'
+];
+
+export function foundWalletMessages(found) {
+  return [
+    `You found a wallet with $${found.toLocaleString()} inside. (+Money)`,
+    `A wallet on the ground held $${found.toLocaleString()}. (+Money)`,
+    `Lucky find! $${found.toLocaleString()} was in a wallet you spotted. (+Money)`,
+    `You stumbled upon $${found.toLocaleString()} in a discarded wallet. (+Money)`,
+    `Someone's lost wallet gave you $${found.toLocaleString()}. (+Money)`
+  ];
+}
+
+export function lostWalletMessages(lost) {
+  return [
+    `You lost your wallet. (-$${lost.toLocaleString()})`,
+    `Your wallet went missing. (-$${lost.toLocaleString()})`,
+    `Misplaced wallet cost you $${lost.toLocaleString()}.`,
+    `You couldn't find your wallet and $${lost.toLocaleString()} vanished.`,
+    `Losing your wallet set you back $${lost.toLocaleString()}.`
+  ];
+}
+
+export const chanceLearningMessages = [
+  'A chance encounter taught you something new. (+Smarts)',
+  'You learned something from a random meeting. (+Smarts)',
+  'An unexpected meeting boosted your knowledge. (+Smarts)',
+  'A random interaction broadened your mind. (+Smarts)',
+  'Serendipity struck, and you learned. (+Smarts)'
+];
+
+export const alreadyDeadMessages = [
+  'You are no longer alive. Start a new life.',
+  'Your life has ended. Begin anew.',
+  "You've passed away. A fresh start awaits.",
+  'Death has come. Start over.',
+  'Your journey ended. Try a new life.'
+];
+
+export const oldAgeDeathMessages = [
+  'You died of old age.',
+  'Old age finally claimed you.',
+  'Your time came due to old age.',
+  'Age caught up; you passed away.',
+  'Life ended peacefully in old age.'
+];
+
+export const studyInJailMessages = [
+  'You studied in jail. (+Smarts)',
+  'Behind bars, you hit the books. (+Smarts)',
+  'Jail time turned into study time. (+Smarts)',
+  'You cracked open books in your cell. (+Smarts)',
+  'Learning continued even in jail. (+Smarts)'
+];
+
+export function studyResultMessages(gain, mood) {
+  return [
+    `You studied hard. +${gain} Smarts${mood < 0 ? ` • ${mood} Happiness` : ''}.`,
+    `Hours of study earned you +${gain} Smarts${mood < 0 ? ` • ${mood} Happiness` : ''}.`,
+    `Focused studying gave you +${gain} Smarts${mood < 0 ? ` • ${mood} Happiness` : ''}.`,
+    `You hit the books for +${gain} Smarts${mood < 0 ? ` • ${mood} Happiness` : ''}.`,
+    `Diligent study boosted you by +${gain} Smarts${mood < 0 ? ` • ${mood} Happiness` : ''}.`
+  ];
+}
+
+export function meditateMessages(happy, smart) {
+  return [
+    `You meditated. +${happy} Happiness, +${smart} Smarts.`,
+    `Meditation brought +${happy} Happiness and +${smart} Smarts.`,
+    `Quiet reflection added +${happy} Happiness and +${smart} Smarts.`,
+    `You found peace: +${happy} Happiness, +${smart} Smarts.`,
+    `Mindfulness rewarded you with +${happy} Happiness and +${smart} Smarts.`
+  ];
+}
+
+export const workExtraNoJobMessages = [
+  'You need a job first.',
+  'Employment comes before overtime.',
+  'Find a job before trying that.',
+  'No job, no overtime.',
+  'Secure work before attempting this.'
+];
+
+export const workExtraJailMessages = [
+  'You cannot work extra while in jail.',
+  'Jail time means no extra work.',
+  'Behind bars, overtime is impossible.',
+  'No overtime from a cell.',
+  "You're locked up—no extra shifts."
+];
+
+export function workExtraResultMessages(bonus) {
+  return [
+    `You took overtime. Earned $${bonus.toLocaleString()}. (-Small Health/Happiness)`,
+    `Extra hours paid $${bonus.toLocaleString()}. (-Small Health/Happiness)`,
+    `Overtime brought in $${bonus.toLocaleString()}. (-Small Health/Happiness)`,
+    `You grabbed overtime for $${bonus.toLocaleString()}. (-Small Health/Happiness)`,
+    `Working extra netted $${bonus.toLocaleString()}. (-Small Health/Happiness)`
+  ];
+}
+
+export const hitGymJailMessages = [
+  'You worked out in the yard. (+Health, +Happiness)',
+  'Yard exercise boosted your stats. (+Health, +Happiness)',
+  'You hit the yard for a workout. (+Health, +Happiness)',
+  'Prison yard training helped you. (+Health, +Happiness)',
+  'Outdoor reps in the yard lifted you. (+Health, +Happiness)'
+];
+
+export const hitGymNoMoneyMessages = [
+  'Not enough money for the gym ($20).',
+  "You can't afford the $20 gym fee.",
+  'Cash shortage keeps you from the gym.',
+  'No $20, no gym visit.',
+  'Your wallet is too light for the gym.'
+];
+
+export const hitGymMessages = [
+  'You hit the gym. (+Health, +Happiness)',
+  'Gym time improved you. (+Health, +Happiness)',
+  'A gym session boosted your stats. (+Health, +Happiness)',
+  'You exercised at the gym. (+Health, +Happiness)',
+  'Workout complete—feeling better. (+Health, +Happiness)'
+];
+
+export const doctorJailMessages = [
+  'No access to a doctor here.',
+  "You can't see a doctor from jail.",
+  "Medical help isn't available here.",
+  'No doctors are reachable right now.',
+  'This place lacks medical care.'
+];
+
+export function doctorNoMoneyMessages(cost) {
+  return [
+    `Doctor visit costs $${cost}. Not enough money.`,
+    `A doctor visit is $${cost}—you can't afford it.`,
+    `No $${cost} for the doctor.`,
+    `Funds are short for a $${cost} doctor visit.`,
+    `You need $${cost} to see the doctor.`
+  ];
+}
+
+export const doctorHealedMessages = [
+  'The doctor treated your illness. (+Health)',
+  'Medical care cured your illness. (+Health)',
+  "The doctor's treatment healed you. (+Health)",
+  'Care from the doctor restored you. (+Health)',
+  'A doctor visit wiped out your illness. (+Health)'
+];
+
+export const doctorCheckupMessages = [
+  'Routine check-up made you feel better. (+Health)',
+  'A simple check-up boosted your health. (+Health)',
+  "The doctor's exam refreshed you. (+Health)",
+  'You felt better after a routine check. (+Health)',
+  'A check-up improved your health. (+Health)'
+];
+
+export const crimeJailMessages = [
+  'You are already in jail.',
+  "You're currently jailed.",
+  "Locked up already, you can't do that.",
+  "You're already behind bars.",
+  'No need for more crime; you\'re in jail.'
+];
+
+export function crimeSuccessMessages(name, amount) {
+  return [
+    `Crime succeeded: ${name}. You gained $${amount.toLocaleString()}.`,
+    `${name} went smoothly—you got $${amount.toLocaleString()}.`,
+    `Success! ${name} netted you $${amount.toLocaleString()}.`,
+    `Your ${name} paid off with $${amount.toLocaleString()}.`,
+    `${name} worked and earned you $${amount.toLocaleString()}.`
+  ];
+}
+
+export function crimeCaughtMessages(name, years) {
+  return [
+    `Busted doing ${name}. You were jailed for ${years} year(s).`,
+    `Caught in the act of ${name}; ${years} year(s) in jail.`,
+    `${name} failed and landed you ${years} year(s) in jail.`,
+    `Authorities nabbed you for ${name}; ${years} year(s) behind bars.`,
+    `Your ${name} attempt backfired—${years} year(s) in jail.`
+  ];
+}
+
+export function crimeInjuryMessages(name, dmg) {
+  return [
+    `Crime failed: ${name}. You were injured (-${dmg} Health).`,
+    `${name} went wrong and you took damage (-${dmg} Health).`,
+    `Failure at ${name} left you hurt (-${dmg} Health).`,
+    `Injury followed a botched ${name} (-${dmg} Health).`,
+    `Attempting ${name} caused harm (-${dmg} Health).`
+  ];
+}

--- a/messages/jailMessages.js
+++ b/messages/jailMessages.js
@@ -1,0 +1,7 @@
+export const releaseMessages = [
+  'You were released from jail.',
+  'Freedom at last—you left jail.',
+  'Your jail time ended and you walked free.',
+  'The prison gates opened; you\'re out.',
+  'You served your sentence and were released.'
+];

--- a/messages/stateMessages.js
+++ b/messages/stateMessages.js
@@ -1,0 +1,7 @@
+export const bornMessages = [
+  'You were born. A new life begins.',
+  'Welcome to the world! A new journey starts.',
+  'A new life springs forth—you were just born.',
+  'You entered the world. The adventure begins.',
+  'A new life dawns as you are born.'
+];

--- a/state.js
+++ b/state.js
@@ -3,6 +3,7 @@ import { rand } from './utils.js';
 import { showEndScreen, hideEndScreen } from './endscreen.js';
 import { faker as fallbackFaker } from './nameGenerator.js';
 import { initBrokers } from './realestate.js';
+import { bornMessages } from './messages/stateMessages.js';
 
 let faker = fallbackFaker;
 
@@ -209,13 +210,7 @@ export function newLife(genderInput, nameInput) {
     log: []
   });
   initBrokers();
-  addLog([
-    'You were born. A new life begins.',
-    'Welcome to the world! A new journey starts.',
-    'A new life springs forth—you were just born.',
-    'You entered the world. The adventure begins.',
-    'A new life dawns as you are born.'
-  ], 'life');
+  addLog(bornMessages, 'life');
   refreshOpenWindows();
   saveGame();
 }


### PR DESCRIPTION
## Summary
- move log message variations into dedicated modules under `messages/`
- replace inline arrays in action, state, and jail logic with imports
- document shared message directory in the README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b965d2ba00832aad8c87df1c8fdb7a