### PR TITLE
Refactor magic numbers into shared constants

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -5,8 +5,8 @@ import { tickRelationships } from './activities/love.js';
 import { tickRealEstate } from './realestate.js';
 import { advanceSchool, accrueStudentLoanInterest } from './school.js';
 import { tickJob, adjustJobPerformance } from './jobs.js';
+import { AGE_JOB_MIN, GYM_COST, PROMOTION_THRESHOLDS } from './constants.js';
 
-const promotionThresholds = { entry: 3, mid: 5 };
 const promotionOrder = { entry: 'mid', mid: 'senior' };
 
 function paySalary() {
@@ -57,7 +57,7 @@ function randomEvent() {
     game.happiness = clamp(game.happiness + 4);
     game.looks = clamp(game.looks - 1);
   }
-  if (game.age === 16) {
+  if (game.age === AGE_JOB_MIN) {
     addLog([
       'You can start looking for a part-time job.',
       'It\'s time to search for a part-time job.',
@@ -203,7 +203,7 @@ export function ageUp() {
     if (game.job) {
       game.jobExperience += 1;
       const next = promotionOrder[game.jobLevel];
-      const threshold = promotionThresholds[game.jobLevel];
+      const threshold = PROMOTION_THRESHOLDS[game.jobLevel];
       if (next && game.jobExperience >= threshold) {
         const base = game.job.baseTitle || game.job.title;
         game.jobExperience = 0;
@@ -351,13 +351,13 @@ export function hitGym() {
     });
     return;
   }
-  const cost = 20;
+  const cost = GYM_COST;
   if (game.money < cost) {
     addLog([
-      'Not enough money for the gym ($20).',
-      'You can\'t afford the $20 gym fee.',
+      `Not enough money for the gym ($${GYM_COST}).`,
+      `You can't afford the $${GYM_COST} gym fee.`,
       'Cash shortage keeps you from the gym.',
-      'No $20, no gym visit.',
+      `No $${GYM_COST}, no gym visit.`,
       'Your wallet is too light for the gym.'
     ], 'health');
     saveGame();

--- a/constants.js
+++ b/constants.js
@@ -1,0 +1,5 @@
+export const AGE_JOB_MIN = 16;
+export const GYM_COST = 20;
+export const PROMOTION_THRESHOLDS = { entry: 3, mid: 5 };
+export const JOB_STRESS_CHANCE = 20;
+export const JOB_PROMOTION_CHANCE = 5;

--- a/jobs.js
+++ b/jobs.js
@@ -1,5 +1,6 @@
 import { rand, clamp } from './utils.js';
 import { game, saveGame, addLog } from './state.js';
+import { JOB_STRESS_CHANCE, JOB_PROMOTION_CHANCE } from './constants.js';
 
 const jobFields = {
   technology: {
@@ -397,7 +398,7 @@ export function tickJob() {
     game.jobSatisfaction = 0;
     return;
   }
-  if (rand(1, 100) <= 20) {
+  if (rand(1, 100) <= JOB_STRESS_CHANCE) {
     const loss = rand(5, 15);
     game.jobSatisfaction = clamp(game.jobSatisfaction - loss);
     addLog(
@@ -409,7 +410,7 @@ export function tickJob() {
       'job'
     );
   }
-  if (rand(1, 100) <= 5) {
+  if (rand(1, 100) <= JOB_PROMOTION_CHANCE) {
     const raise = rand(1000, 5000);
     const gain = rand(10, 20);
     game.job.salary += raise;

--- a/renderers/actions.js
+++ b/renderers/actions.js
@@ -1,7 +1,21 @@
 import { game } from '../state.js';
-import { ageUp, study, meditate, hitGym, workExtra, seeDoctor, crime, dropOut, enrollCollege, enrollUniversity, reEnrollHighSchool, getGed } from '../actions.js';
+import {
+  ageUp,
+  study,
+  meditate,
+  hitGym,
+  workExtra,
+  seeDoctor,
+  crime,
+  dropOut,
+  enrollCollege,
+  enrollUniversity,
+  reEnrollHighSchool,
+  getGed
+} from '../actions.js';
 import { toggleWindow } from '../windowManager.js';
 import { renderJobs } from './jobs.js';
+import { AGE_JOB_MIN } from '../constants.js';
 
 export function renderActions(container) {
   const g = document.createElement('div');
@@ -23,7 +37,7 @@ export function renderActions(container) {
   g.appendChild(mk('💵 Work Overtime (+$$)', workExtra, dead || !game.job || game.inJail));
   g.appendChild(mk('🩺 See Doctor', seeDoctor, dead));
   g.appendChild(mk('🕶️ Crime (risky)', crime, dead));
-  if (!dead && game.age >= 16 && game.education.current === 'high' && !game.education.droppedOut) {
+  if (!dead && game.age >= AGE_JOB_MIN && game.education.current === 'high' && !game.education.droppedOut) {
     g.appendChild(mk('🚪 Drop Out of School', dropOut));
   }
   if (!dead && game.education.droppedOut && !game.education.current) {
@@ -40,7 +54,7 @@ export function renderActions(container) {
   note.className = 'muted';
   note.style.marginTop = '8px';
   let txt = 'Actions adjust your stats. Some actions are limited while in jail.';
-  if (game.age < 16) txt += ' You are under 16, so most jobs are unavailable yet.';
+  if (game.age < AGE_JOB_MIN) txt += ` You are under ${AGE_JOB_MIN}, so most jobs are unavailable yet.`;
   if (game.inJail) txt += ' You are in jail: Work/Doctor/Crime disabled. You can still age, study, and work out.';
   note.textContent = txt;
   g.appendChild(note);

--- a/renderers/jobs.js
+++ b/renderers/jobs.js
@@ -2,12 +2,13 @@ import { game, addLog, saveGame, unlockAchievement } from '../state.js';
 import { generateJobs } from '../jobs.js';
 import { refreshOpenWindows } from '../windowManager.js';
 import { educationRank, eduName } from '../school.js';
+import { AGE_JOB_MIN, PROMOTION_THRESHOLDS } from '../constants.js';
 
 export function renderJobs(container) {
   const head = document.createElement('div');
   head.className = 'muted';
-  if (game.age < 16) {
-    head.textContent = 'You are too young to work. Come back at age 16+';
+  if (game.age < AGE_JOB_MIN) {
+    head.textContent = `You are too young to work. Come back at age ${AGE_JOB_MIN}+`;
     container.appendChild(head);
     return;
   }
@@ -29,10 +30,9 @@ export function renderJobs(container) {
     container.appendChild(perf);
     const info = document.createElement('div');
     info.className = 'muted';
-    const thresholds = { entry: 3, mid: 5 };
     const next = game.jobLevel === 'entry' ? 'mid' : game.jobLevel === 'mid' ? 'senior' : null;
     if (next) {
-      info.textContent = `Current Level: ${game.jobLevel} (${game.jobExperience}/${thresholds[game.jobLevel]} yrs to ${next})`;
+      info.textContent = `Current Level: ${game.jobLevel} (${game.jobExperience}/${PROMOTION_THRESHOLDS[game.jobLevel]} yrs to ${next})`;
     } else {
       info.textContent = `Current Level: ${game.jobLevel} (max level)`;
     }

--- a/school.js
+++ b/school.js
@@ -1,4 +1,5 @@
 import { game, addLog, applyAndSave, saveGame } from './state.js';
+import { AGE_JOB_MIN } from './constants.js';
 
 export const EDU_LEVELS = ['none', 'elementary', 'middle', 'trade', 'high', 'college', 'university', 'masters', 'phd'];
 
@@ -91,7 +92,7 @@ export function advanceSchool() {
 }
 
 export function dropOut() {
-  if (game.age < 16 || game.education.current !== 'high' || game.education.droppedOut) {
+  if (game.age < AGE_JOB_MIN || game.education.current !== 'high' || game.education.droppedOut) {
     addLog('You cannot drop out right now.', 'education');
     saveGame();
     return;

--- a/tests/constants.test.js
+++ b/tests/constants.test.js
@@ -1,0 +1,18 @@
+import {
+  AGE_JOB_MIN,
+  GYM_COST,
+  PROMOTION_THRESHOLDS,
+  JOB_STRESS_CHANCE,
+  JOB_PROMOTION_CHANCE
+} from '../constants.js';
+
+describe('game constants', () => {
+  test('exports expected values', () => {
+    expect(AGE_JOB_MIN).toBe(16);
+    expect(GYM_COST).toBe(20);
+    expect(PROMOTION_THRESHOLDS.entry).toBe(3);
+    expect(PROMOTION_THRESHOLDS.mid).toBe(5);
+    expect(JOB_STRESS_CHANCE).toBe(20);
+    expect(JOB_PROMOTION_CHANCE).toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary
- add `constants.js` for age, gym cost, and job-related thresholds
- replace inline magic numbers in actions, jobs, school, and renderers with shared constants
- cover constants with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b965d45358832a81d316f34d0a3aa5