### PR TITLE
Add keyboard window movement and ARIA drag roles

### DIFF
--- a/partials/window-template.html
+++ b/partials/window-template.html
@@ -1,5 +1,5 @@
 <div class="window" role="dialog" aria-label="Window" style="left: 100px; top: 100px;">
-  <div class="titlebar">
+  <div class="titlebar" role="toolbar" aria-label="Window controls" aria-grabbed="false">
     <span class="title">Window</span>
     <div class="controls">
       <div class="control-btn btn-close" role="button" title="Close" aria-label="Close">✕</div>

--- a/renderers/help.js
+++ b/renderers/help.js
@@ -4,6 +4,7 @@ export function renderHelp(container) {
   const lines = [
     'Goal: live as long as you can while improving your stats.',
     'Drag window title bars to move them. Use the dock buttons to show or hide windows.',
+    'With a window title bar focused, use Arrow keys to reposition it.',
     'Use the Actions window to age up and progress through life.',
     'Jobs unlock at age 16. Visit Job Hunt to start working and earn money.'
   ];

--- a/windowManager.js
+++ b/windowManager.js
@@ -112,6 +112,7 @@ function makeDraggable(win) {
     dragging = true;
     win.classList.add('dragging');
     bringToFront(win);
+    bar.setAttribute('aria-grabbed', 'true');
     const rect = win.getBoundingClientRect();
     startLeft = rect.left;
     startTop = rect.top;
@@ -140,6 +141,7 @@ function makeDraggable(win) {
     win.classList.remove('dragging');
     bar.releasePointerCapture?.(e.pointerId);
     savePosition(win);
+    bar.setAttribute('aria-grabbed', 'false');
   };
 
   bar.addEventListener('pointerdown', onDown);
@@ -168,6 +170,7 @@ function makeDraggable(win) {
       closeWindow(win.dataset.id);
       return;
     }
+    if (e.target !== bar) return;
     const step = 10;
     let moved = false;
     let left = parseInt(win.style.left, 10) || 0;
@@ -187,6 +190,7 @@ function makeDraggable(win) {
     }
     if (moved) {
       e.preventDefault();
+      bar.setAttribute('aria-grabbed', 'true');
       const dRect = desktop.getBoundingClientRect();
       const maxLeft = dRect.width - win.offsetWidth - 4;
       const maxTop = dRect.height - win.offsetHeight - 4;
@@ -196,6 +200,7 @@ function makeDraggable(win) {
       win.style.top = top + 'px';
       savePosition(win);
       bringToFront(win);
+      bar.setAttribute('aria-grabbed', 'false');
     }
   });
 }


### PR DESCRIPTION
## Summary
- allow moving windows with Arrow keys when a window's title bar is focused
- update ARIA attributes so the title bar reflects draggable state
- document Arrow key window movement in help renderer

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b965d6e064832ab4f6c27db797f6c4