### PR TITLE
Add meditation retreat activity

### DIFF
--- a/activities/meditationRetreat.js
+++ b/activities/meditationRetreat.js
@@ -1,0 +1,33 @@
+import { game, addLog, applyAndSave } from '../state.js';
+import { clamp, rand } from '../utils.js';
+
+export function renderMeditationRetreat(container) {
+  const head = document.createElement('div');
+  head.className = 'muted';
+  head.textContent = 'Spend time at a meditation retreat to restore your mind and body.';
+  container.appendChild(head);
+
+  const btn = document.createElement('button');
+  btn.className = 'btn';
+  btn.textContent = 'Attend Retreat ($300)';
+  btn.addEventListener('click', () => {
+    const cost = 300;
+    if (game.money < cost) {
+      applyAndSave(() => {
+        addLog(`Retreat costs $${cost}. Not enough money.`, 'health');
+      });
+      return;
+    }
+    applyAndSave(() => {
+      game.money -= cost;
+      const happy = rand(6, 12);
+      const health = rand(4, 8);
+      game.happiness = clamp(game.happiness + happy);
+      game.health = clamp(game.health + health);
+      addLog(`You attended a meditation retreat. +${happy} Happiness, +${health} Health.`, 'health');
+    });
+  });
+
+  container.appendChild(btn);
+}
+

--- a/renderers/activities.js
+++ b/renderers/activities.js
@@ -49,7 +49,8 @@ const ACTIVITIES_CATEGORIES = {
     'Doctor',
     'Plastic Surgery',
     'Rehab',
-    'Mind & Work'
+    'Mind & Work',
+    'Meditation Retreat'
   ],
   'Travel & Community': [
     'Commune',
@@ -76,6 +77,7 @@ const ACTIVITY_RENDERERS = {
   Emigrate: () => openActivity('emigrate', 'Emigrate', '../activities/emigrate.js', 'renderEmigrate'),
   Commune: () => openActivity('commune', 'Commune', '../activities/commune.js', 'renderCommune'),
   'Mind & Work': () => openActivity('mindwork', 'Mind & Work', '../activities/mindAndWork.js', 'renderMindAndWork'),
+  'Meditation Retreat': () => openActivity('meditationRetreat', 'Meditation Retreat', '../activities/meditationRetreat.js', 'renderMeditationRetreat'),
   Rehab: () => openActivity('rehab', 'Rehab', '../activities/rehab.js', 'renderRehab'),
   'Will & Testament': () => openActivity('will', 'Will & Testament', '../activities/willAndTestament.js', 'renderWillAndTestament'),
   Licenses: () => openActivity('licenses', 'Licenses', '../activities/licenses.js', 'renderLicenses'),


### PR DESCRIPTION
## Summary
- add Meditation Retreat activity to boost happiness and health
- hook Meditation Retreat into activity menu and launcher

## Testing
- `npm test` *(fails: Cannot find module '../actions.js' from 'tests/actions.health.test.js'; SyntaxError in tests/realestate.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b96aaa9994832a9494affc98aa093c