### PR TITLE
feat: add scratch-off lottery option

### DIFF
--- a/activities/lottery.js
+++ b/activities/lottery.js
@@ -4,7 +4,7 @@ import { openWindow } from '../windowManager.js';
 
 export { openWindow };
 
-export function renderLottery(container) {
+function renderStandardLottery(container) {
   const wrap = document.createElement('div');
   const btn = document.createElement('button');
   btn.className = 'btn';
@@ -37,6 +37,75 @@ export function renderLottery(container) {
     });
   });
   wrap.appendChild(btn);
+  container.appendChild(wrap);
+}
+
+export function renderScratchOff(container) {
+  const wrap = document.createElement('div');
+  const btn = document.createElement('button');
+  btn.className = 'btn';
+  btn.textContent = 'Scratch-Off ($2)';
+  btn.disabled = game.money < 2;
+  btn.addEventListener('click', () => {
+    if (game.money < 2) return;
+    applyAndSave(() => {
+      game.money -= 2;
+      const roll = rand(1, 100);
+      let prize = 0;
+      let mood = -1;
+      let msg = 'You scratched the ticket but won nothing.';
+      if (roll === 1) {
+        prize = 500;
+        mood = 10;
+        msg = `Jackpot! You won $${prize}.`;
+      } else if (roll <= 10) {
+        prize = 50;
+        mood = 4;
+        msg = `You won $${prize}.`;
+      } else if (roll <= 30) {
+        prize = 10;
+        mood = 1;
+        msg = `You won $${prize}.`;
+      }
+      game.money += prize;
+      game.happiness = clamp(game.happiness + mood);
+      addLog(msg, 'gambling');
+    });
+  });
+  wrap.appendChild(btn);
+  container.appendChild(wrap);
+}
+
+export function renderLottery(container) {
+  const wrap = document.createElement('div');
+
+  const select = document.createElement('select');
+  const optStandard = document.createElement('option');
+  optStandard.value = 'standard';
+  optStandard.textContent = 'Standard Lottery';
+  select.appendChild(optStandard);
+  const optScratch = document.createElement('option');
+  optScratch.value = 'scratch';
+  optScratch.textContent = 'Scratch-Off Ticket';
+  select.appendChild(optScratch);
+  wrap.appendChild(select);
+
+  const content = document.createElement('div');
+  content.style.marginTop = '8px';
+  wrap.appendChild(content);
+
+  const renderCurrent = () => {
+    content.innerHTML = '';
+    if (select.value === 'scratch') {
+      renderScratchOff(content);
+    } else {
+      renderStandardLottery(content);
+    }
+  };
+
+  select.addEventListener('change', renderCurrent);
+  renderCurrent();
+
   container.appendChild(wrap);
 }
 


### PR DESCRIPTION
## Summary
- add `renderScratchOff` for scratch-off ticket play with randomized payouts
- allow choosing between standard lottery and scratch-off in `renderLottery`

## Testing
- `npm test` *(fails: Cannot find module '../actions.js' from tests/actions.health.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b96ab5dbf4832abbe3e967bb321afe