### PR TITLE
Add Game Developer roles and Computer Science major option

### DIFF
--- a/jobs.js
+++ b/jobs.js
@@ -24,7 +24,8 @@ const jobFields = {
       ['UX Designer', 68000, 'college'],
       ['Engineer', 52000, 'university'],
       ['Systems Analyst', 61000, 'college'],
-      ['IT Specialist', 55000, 'trade']
+      ['IT Specialist', 55000, 'trade'],
+      ['Game Developer', 71000, 'college', 'Computer Science']
     ],
     senior: [
       ['Senior Software Engineer', 90000, 'university'],
@@ -32,7 +33,8 @@ const jobFields = {
       ['Chief Technology Officer', 150000, 'university'],
       ['Lead Data Scientist', 125000, 'university'],
       ['Security Architect', 115000, 'university'],
-      ['AI Researcher', 130000, 'university']
+      ['AI Researcher', 130000, 'university'],
+      ['Senior Game Developer', 135000, 'university', 'Computer Science']
     ]
   },
   healthcare: {

--- a/school.js
+++ b/school.js
@@ -18,6 +18,8 @@ const tuition = {
   university: 40000
 };
 
+export const MAJORS = ['Computer Science', 'Nursing', 'Finance'];
+
 export function educationRank(level) {
   return EDU_LEVELS.indexOf(level || 'none');
 }
@@ -48,6 +50,9 @@ export function eduName(level) {
 function startStage(stage) {
   game.education.current = stage;
   game.education.progress = 0;
+  if (educationRank(stage) >= educationRank('college')) {
+    game.education.major = null;
+  }
   addLog(`You started ${eduName(stage)}.`, 'education');
 }
 
@@ -127,6 +132,24 @@ export function getGed() {
     game.education.progress = 0;
     game.education.droppedOut = false;
     addLog('You obtained a GED.', 'education');
+  });
+}
+
+export function chooseMajor(major) {
+  const level = game.education.current || game.education.highest;
+  if (educationRank(level) < educationRank('college')) {
+    addLog('You need to be in college or higher to choose a major.', 'education');
+    saveGame();
+    return;
+  }
+  if (!MAJORS.includes(major)) {
+    addLog('That major is not available.', 'education');
+    saveGame();
+    return;
+  }
+  applyAndSave(() => {
+    game.education.major = major;
+    addLog(`You chose ${major} as your major.`, 'education');
   });
 }
 

--- a/tests/school.test.js
+++ b/tests/school.test.js
@@ -39,7 +39,7 @@ jest.unstable_mockModule('../realestate.js', () => ({
 
 const school = await import('../school.js');
 const state = await import('../state.js');
-const { advanceSchool, dropOut, reEnrollHighSchool, getGed } = school;
+const { advanceSchool, dropOut, reEnrollHighSchool, getGed, chooseMajor } = school;
 const { game } = state;
 
 beforeEach(() => {
@@ -107,5 +107,18 @@ describe('getGed', () => {
     expect(game.education.progress).toBe(0);
     expect(game.education.droppedOut).toBe(false);
     expect(game.log[0].text).toBe('You obtained a GED.');
+  });
+});
+
+describe('chooseMajor', () => {
+  test('blocks major selection before college', () => {
+    chooseMajor('Computer Science');
+    expect(game.education.major).toBeNull();
+  });
+
+  test('allows choosing Computer Science in college', () => {
+    game.education.highest = 'college';
+    chooseMajor('Computer Science');
+    expect(game.education.major).toBe('Computer Science');
   });
 });


### PR DESCRIPTION
## Summary
- add Game Developer job to technology mid-tier and Senior Game Developer to senior tier
- support choosing Computer Science major for higher education levels and reset major when entering college or beyond
- test major selection behavior in school module

## Testing
- `npm test` *(fails: Cannot find module '../actions.js' and unexpected token in tests/realestate.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b96ab03a48832a89edfecc30f9eb96