### PR TITLE
Add skill system for gambling and racing activities

### DIFF
--- a/activities/gamble.js
+++ b/activities/gamble.js
@@ -31,7 +31,8 @@ export function renderGamble(container) {
     }
     applyAndSave(() => {
       game.money -= bet;
-      if (rand(0, 1) === 1) {
+      const chance = Math.min(50 + game.skills.gambling, 90);
+      if (rand(1, 100) <= chance) {
         const payout = bet * 2;
         game.money += payout;
         addLog(`You won $${payout}.`, 'gambling');
@@ -40,6 +41,7 @@ export function renderGamble(container) {
         addLog(`You lost $${bet}.`, 'gambling');
         result.textContent = 'Result: Loss';
       }
+      game.skills.gambling += 1;
     });
   });
 

--- a/activities/racing.js
+++ b/activities/racing.js
@@ -14,8 +14,9 @@ export function renderRacing(container) {
   vehicleBtn.textContent = 'Race Vehicles';
   vehicleBtn.addEventListener('click', () => {
     applyAndSave(() => {
-      if (rand(0, 1) === 0) {
-        const prize = rand(200, 500);
+      const chance = Math.min(50 + game.skills.racing, 90);
+      if (rand(1, 100) <= chance) {
+        const prize = rand(200, 500) + game.skills.racing * 10;
         game.money += prize;
         game.happiness = clamp(game.happiness + rand(5, 10));
         addLog(`You won a vehicle race and earned $${prize}.`, 'leisure');
@@ -25,6 +26,7 @@ export function renderRacing(container) {
         game.happiness = clamp(game.happiness - rand(5, 10));
         addLog(`You crashed during a vehicle race. -${dmg} Health.`, 'leisure');
       }
+      game.skills.racing += 1;
     });
   });
   wrap.appendChild(vehicleBtn);
@@ -34,8 +36,9 @@ export function renderRacing(container) {
   footBtn.textContent = 'Race on Foot';
   footBtn.addEventListener('click', () => {
     applyAndSave(() => {
-      if (rand(0, 1) === 0) {
-        const gain = rand(5, 10);
+      const chance = Math.min(50 + game.skills.racing, 90);
+      if (rand(1, 100) <= chance) {
+        const gain = rand(5, 10) + Math.floor(game.skills.racing / 5);
         game.health = clamp(game.health + gain);
         game.happiness = clamp(game.happiness + rand(2, 6));
         addLog(`You won the foot race. +${gain} Health.`, 'leisure');
@@ -45,6 +48,7 @@ export function renderRacing(container) {
         game.happiness = clamp(game.happiness - rand(1, 4));
         addLog(`You lost the foot race. -${loss} Health.`, 'leisure');
       }
+      game.skills.racing += 1;
     });
   });
   wrap.appendChild(footBtn);

--- a/state.js
+++ b/state.js
@@ -56,6 +56,10 @@ export const game = {
   sick: false,
   inJail: false,
   alive: true,
+  skills: {
+    gambling: 0,
+    racing: 0
+  },
   log: []
 };
 
@@ -123,6 +127,9 @@ export function loadGame() {
   if (!data) return false;
   try {
     Object.assign(game, JSON.parse(data));
+    if (!game.skills) {
+      game.skills = { gambling: 0, racing: 0 };
+    }
   } catch {
     localStorage.removeItem('gameState');
     return false;
@@ -197,6 +204,10 @@ export function newLife(genderInput, nameInput) {
     sick: false,
     inJail: false,
     alive: true,
+    skills: {
+      gambling: 0,
+      racing: 0
+    },
     log: []
   });
   initBrokers();


### PR DESCRIPTION
## Summary
- track gambling and racing skills on the game state
- boost gambling wins and racing outcomes based on skill levels
- grow relevant skill with each activity attempt

## Testing
- `npm test` *(fails: Cannot find module '../actions.js' from 'tests/actions.health.test.js'; Cannot find module '../actions.js' from 'tests/actions.ageUp.test.js'; SyntaxError in tests/realestate.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b96ab707f4832abe7b24fd6e079316