### PR TITLE
Add market news system

### DIFF
--- a/investment.js
+++ b/investment.js
@@ -1,0 +1,31 @@
+import { game, addLog, saveGame } from './state.js';
+import { rand } from './utils.js';
+import { generateMarketNews } from './utils/marketNews.js';
+
+if (!('portfolio' in game)) {
+  game.portfolio = 0;
+}
+
+export function invest(amount) {
+  if (game.money < amount) {
+    addLog('Not enough money to invest.', 'investment');
+    return false;
+  }
+  game.money -= amount;
+  game.portfolio += amount;
+  addLog(`You invested $${amount.toLocaleString()}.`, 'investment');
+  saveGame();
+  return true;
+}
+
+export function tickInvestments() {
+  if (!game.portfolio) return;
+  const news = generateMarketNews();
+  const base = rand(95, 105) / 100;
+  const modifier = base * news.modifier;
+  game.portfolio = Math.round(game.portfolio * modifier);
+  addLog(news.headline, 'news');
+  addLog(`Your portfolio is now worth $${game.portfolio.toLocaleString()}.`, 'investment');
+  saveGame();
+}
+

--- a/renderers/log.js
+++ b/renderers/log.js
@@ -1,6 +1,10 @@
 import { game } from '../state.js';
 
 export function renderLog(container) {
+  const headlineBox = document.createElement('div');
+  headlineBox.className = 'headlines';
+  container.appendChild(headlineBox);
+
   const categories = Array.from(new Set(game.log.map(l => l.category || 'general')));
   const select = document.createElement('select');
   const allOpt = document.createElement('option');
@@ -19,6 +23,17 @@ export function renderLog(container) {
   list.className = 'log';
   list.setAttribute('aria-live', 'polite');
   container.appendChild(list);
+
+  const renderHeadlines = () => {
+    headlineBox.innerHTML = '';
+    const headlines = game.log.filter(l => l.category === 'news').slice(0, 5);
+    for (const h of headlines) {
+      const div = document.createElement('div');
+      div.className = 'headline';
+      div.textContent = h.text;
+      headlineBox.appendChild(div);
+    }
+  };
 
   const renderList = () => {
     list.innerHTML = '';
@@ -40,8 +55,10 @@ export function renderLog(container) {
         list.appendChild(e);
       }
     }
+    renderHeadlines();
   };
 
   select.addEventListener('change', renderList);
+  renderHeadlines();
   renderList();
 }

--- a/utils/marketNews.js
+++ b/utils/marketNews.js
@@ -1,0 +1,13 @@
+import { rand } from '../utils.js';
+
+const newsEvents = [
+  { headline: 'Tech stocks soar on innovation surge', modifier: 1.1 },
+  { headline: 'Economic slowdown rattles markets', modifier: 0.9 },
+  { headline: 'Energy sector rallies on new discoveries', modifier: 1.05 },
+  { headline: 'Regulation fears trigger sell-off', modifier: 0.95 }
+];
+
+export function generateMarketNews() {
+  return newsEvents[rand(0, newsEvents.length - 1)];
+}
+


### PR DESCRIPTION
## Summary
- add market news generator with modifier data
- adjust investment calculations based on daily news
- show latest news headlines at top of log view

## Testing
- `npm test` *(fails: Cannot find module '../actions.js' from 'tests/actions.health.test.js')*

------
https://chatgpt.com/codex/tasks/task_e_68b96b4f5d90832a8e66c914d7f2dc2b