### PR TITLE
Add commute traffic accident checks

### DIFF
--- a/actions/job.js
+++ b/actions/job.js
@@ -1,9 +1,17 @@
 import { game, addLog, saveGame, applyAndSave } from '../state.js';
 import { rand, clamp } from '../utils.js';
 import { adjustJobPerformance } from '../jobs.js';
+import { checkForAccident } from './traffic.js';
+
+function commute() {
+  if (game.car) {
+    checkForAccident();
+  }
+}
 
 export function paySalary() {
   if (game.job && !game.inJail) {
+    commute();
     adjustJobPerformance();
     const monthly = game.job.salary / 12;
     const months = rand(10, 12);
@@ -63,6 +71,7 @@ export function workExtra() {
     saveGame();
     return;
   }
+  commute();
   applyAndSave(() => {
     const bonus = rand(200, 1500);
     game.money += bonus;

--- a/actions/traffic.js
+++ b/actions/traffic.js
@@ -1,0 +1,20 @@
+import { game } from '../state.js';
+import { rand, clamp } from '../utils.js';
+import { logTraffic } from '../renderers/log.js';
+
+export function checkForAccident() {
+  if (rand(1, 100) > 10) {
+    return null;
+  }
+  if (rand(0, 1) === 0) {
+    const injury = rand(5, 15);
+    game.health = clamp(game.health - injury);
+    logTraffic(`You were injured in a car accident. -${injury} Health.`);
+    return { injury };
+  }
+  const fine = rand(100, 500);
+  game.money = Math.max(0, game.money - fine);
+  logTraffic(`You were fined $${fine.toLocaleString()} for a traffic violation.`);
+  return { fine };
+}
+

--- a/renderers/log.js
+++ b/renderers/log.js
@@ -1,4 +1,4 @@
-import { game } from '../state.js';
+import { game, addLog } from '../state.js';
 
 export function renderLog(container) {
   const categories = Array.from(new Set(game.log.map(l => l.category || 'general')));
@@ -44,4 +44,8 @@ export function renderLog(container) {
 
   select.addEventListener('change', renderList);
   renderList();
+}
+
+export function logTraffic(text) {
+  addLog(text, 'traffic');
 }


### PR DESCRIPTION
## Summary
- add traffic accident events with injury or fine outcomes
- check for accidents when commuting to work if a car is owned
- expose `logTraffic` helper so traffic events show in the log

## Testing
- `npm test` *(fails: Cannot find module '../actions.js' in multiple test files; SyntaxError in tests/realestate.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b96b4524d0832abcd0aab0dace7f3d