### PR TITLE
feat: add property renovation

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -1,0 +1,2 @@
+export * from './actions/index.js';
+

--- a/actions/index.js
+++ b/actions/index.js
@@ -306,4 +306,5 @@ export { dropOut, enrollCollege, enrollUniversity, reEnrollHighSchool, getGed } 
 export { workExtra } from './job.js';
 export { seeDoctor } from './health.js';
 export { crime } from './crime.js';
+export { renovateProperty } from './renovateProperty.js';
 

--- a/actions/renovateProperty.js
+++ b/actions/renovateProperty.js
@@ -1,0 +1,39 @@
+import { game, addLog, saveGame, applyAndSave } from '../state.js';
+
+/**
+ * Starts a renovation on a property, deducting cost and setting duration.
+ * Tenant is removed and rent resets during renovation.
+ * @param {object} prop - Property to renovate.
+ * @param {number} cost - Renovation cost.
+ * @param {number} years - Years the renovation will take.
+ * @returns {void}
+ */
+export function renovateProperty(prop, cost, years) {
+  const price = Math.round(cost);
+  const duration = Math.max(1, Math.floor(years));
+  if (prop.renovation) {
+    addLog(`${prop.name} is already being renovated.`, 'property');
+    saveGame();
+    return;
+  }
+  if (game.money < price) {
+    addLog(
+      `Renovating ${prop.name} costs $${price.toLocaleString()}. Not enough money.`,
+      'property'
+    );
+    saveGame();
+    return;
+  }
+  applyAndSave(() => {
+    game.money -= price;
+    prop.rented = false;
+    prop.rent = 0;
+    prop.tenant = null;
+    prop.renovation = { years: duration, cost: price };
+    addLog(
+      `You started renovating ${prop.name}. (-$${price.toLocaleString()})`,
+      'property'
+    );
+  });
+}
+

--- a/activities/renovation.js
+++ b/activities/renovation.js
@@ -1,0 +1,53 @@
+import { game } from '../state.js';
+import { openWindow } from '../windowManager.js';
+import { renovateProperty } from '../actions/renovateProperty.js';
+
+export { openWindow };
+
+/**
+ * Renders the renovation interface to start property renovations.
+ * @param {HTMLElement} container - The DOM element to render into.
+ * @returns {void}
+ */
+export function renderRenovation(container) {
+  const wrap = document.createElement('div');
+  if (game.properties.length === 0) {
+    wrap.textContent = 'You own no properties.';
+    container.appendChild(wrap);
+    return;
+  }
+  game.properties.forEach(prop => {
+    const row = document.createElement('div');
+    const info = document.createElement('span');
+    info.textContent = `${prop.name} (Value $${prop.value.toLocaleString()})`;
+    const costInput = document.createElement('input');
+    costInput.type = 'number';
+    costInput.min = '1';
+    costInput.value = Math.round(prop.value * 0.1);
+    costInput.style.width = '80px';
+    const yearInput = document.createElement('input');
+    yearInput.type = 'number';
+    yearInput.min = '1';
+    yearInput.value = '1';
+    yearInput.style.width = '40px';
+    const btn = document.createElement('button');
+    btn.className = 'btn';
+    btn.textContent = 'Renovate';
+    btn.addEventListener('click', () => {
+      const cost = Math.floor(Number(costInput.value));
+      const yrs = Math.floor(Number(yearInput.value));
+      if (cost > 0 && yrs > 0) {
+        renovateProperty(prop, cost, yrs);
+      }
+    });
+    row.appendChild(info);
+    row.appendChild(document.createTextNode(' Cost $'));
+    row.appendChild(costInput);
+    row.appendChild(document.createTextNode(' Years '));
+    row.appendChild(yearInput);
+    row.appendChild(btn);
+    wrap.appendChild(row);
+  });
+  container.appendChild(wrap);
+}
+

--- a/realestate.js
+++ b/realestate.js
@@ -182,7 +182,8 @@ export function buyProperty(broker, listing) {
     rented: false,
     rent: 0,
     tenant: null,
-    icon: listing.icon
+    icon: listing.icon,
+    renovation: null
   };
   game.properties.push(prop);
   broker.listings = broker.listings.filter(l => l !== listing);
@@ -251,6 +252,20 @@ export function tickRealEstate() {
     const tax = Math.round(prop.value * 0.01);
     game.money -= tax;
     addLog(`Paid $${tax.toLocaleString()} in property tax for ${prop.name}.`);
+    if (prop.renovation) {
+      prop.renovation.years -= 1;
+      if (prop.renovation.years <= 0) {
+        const increase = Math.round(prop.renovation.cost * 1.5);
+        prop.value += increase;
+        prop.condition = 100;
+        addLog(
+          `Renovation complete on ${prop.name}. Value increased by $${increase.toLocaleString()}.`,
+          'property'
+        );
+        prop.renovation = null;
+      }
+      continue;
+    }
     if (prop.rented) {
       game.money += prop.rent;
       prop.condition = clamp(prop.condition - rand(1, 3), 0, 100);

--- a/renderers/realestate.js
+++ b/renderers/realestate.js
@@ -68,12 +68,14 @@ export function renderRealEstate(container) {
       }
       icon.style.marginRight = '4px';
       info.appendChild(icon);
-      info.appendChild(
-        document.createTextNode(` ${p.name} - Val $${p.value.toLocaleString()} - Cond ${p.condition}%`)
-      );
+      let text = ` ${p.name} - Val $${p.value.toLocaleString()} - Cond ${p.condition}%`;
+      if (p.renovation) {
+        text += ` - Renovation ${p.renovation.years} yr${p.renovation.years > 1 ? 's' : ''} left`;
+      }
+      info.appendChild(document.createTextNode(text));
       row.appendChild(info);
       const rentDiv = document.createElement('div');
-      if (!p.rented) {
+      if (!p.rented && !p.renovation) {
         const input = document.createElement('input');
         input.type = 'number';
         input.min = 1;
@@ -87,21 +89,31 @@ export function renderRealEstate(container) {
         });
         rentDiv.appendChild(input);
         rentDiv.appendChild(rentBtn);
-      } else {
+      } else if (p.rented) {
         const span = document.createElement('span');
         span.textContent = `Rented to ${p.tenant} ($${p.rent.toLocaleString()}/yr)`;
+        rentDiv.appendChild(span);
+      } else {
+        const span = document.createElement('span');
+        span.textContent = 'Under renovation';
         rentDiv.appendChild(span);
       }
       row.appendChild(rentDiv);
       const repairDiv = document.createElement('div');
-      [10, 25, 50, 100].forEach(pct => {
-        const b = document.createElement('button');
-        b.textContent = `${pct}% Repair`;
-        b.addEventListener('click', () => {
-          repairProperty(p, pct);
+      if (p.renovation) {
+        const span = document.createElement('span');
+        span.textContent = 'Under renovation';
+        repairDiv.appendChild(span);
+      } else {
+        [10, 25, 50, 100].forEach(pct => {
+          const b = document.createElement('button');
+          b.textContent = `${pct}% Repair`;
+          b.addEventListener('click', () => {
+            repairProperty(p, pct);
+          });
+          repairDiv.appendChild(b);
         });
-        repairDiv.appendChild(b);
-      });
+      }
       row.appendChild(repairDiv);
       const sellDiv = document.createElement('div');
       const sellBtn = document.createElement('button');


### PR DESCRIPTION
## Summary
- allow properties to enter renovation, pausing rent and evicting tenants
- add renovation activity UI for starting upgrades with cost and duration
- raise property value when renovations finish

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b96b3fc1a8832a91b2500be2ed4578