### PR TITLE
feat: add influencer career path

### DIFF
--- a/activities/socialMedia.js
+++ b/activities/socialMedia.js
@@ -1,5 +1,6 @@
 import { game, addLog, applyAndSave } from '../state.js';
 import { clamp, rand } from '../utils.js';
+import { generateJobs } from '../jobs.js';
 
 export function renderSocialMedia(container) {
   if (typeof game.followers !== 'number') game.followers = 0;
@@ -16,6 +17,11 @@ export function renderSocialMedia(container) {
   count.style.margin = '4px 0';
   wrap.appendChild(count);
 
+  function refreshJobs() {
+    game.jobListingsYear = null;
+    generateJobs();
+  }
+
   const post = document.createElement('button');
   post.className = 'btn';
   post.textContent = 'Post Update';
@@ -27,6 +33,7 @@ export function renderSocialMedia(container) {
       game.happiness = clamp(game.happiness + gain);
       addLog(`You posted on social media and gained ${gained} followers.`, 'social');
       count.textContent = `Followers: ${game.followers}`;
+      refreshJobs();
     });
   });
 
@@ -48,6 +55,7 @@ export function renderSocialMedia(container) {
       game.happiness = clamp(game.happiness + 5);
       addLog(`You promoted your account and gained ${gained} followers.`, 'social');
       count.textContent = `Followers: ${game.followers}`;
+      refreshJobs();
     });
   });
 

--- a/jobs.js
+++ b/jobs.js
@@ -301,11 +301,23 @@ const jobFields = {
       ['Fleet Manager', 85000, 'university'],
       ['Chief Transportation Officer', 110000, 'university']
     ]
-  } 
+  },
+  influencer: {
+    entry: [
+      ['Micro Influencer', 30000, 'none', null, 1000]
+    ],
+    mid: [
+      ['Social Media Star', 70000, 'none', null, 10000]
+    ],
+    senior: [
+      ['Celebrity Influencer', 150000, 'none', null, 100000]
+    ]
+  }
 };
 
 const fieldDiscoveryYear = {
-  technology: 1940
+  technology: 1940,
+  influencer: 2005
 };
 
 const jobDiscoveryYear = {
@@ -333,7 +345,7 @@ const allJobs = [];
 for (const [field, levels] of Object.entries(jobFields)) {
   const fieldYear = fieldDiscoveryYear[field] || 0;
   for (const [level, jobs] of Object.entries(levels)) {
-    for (const [title, base, edu, major] of jobs) {
+    for (const [title, base, edu, major, followers] of jobs) {
       const availableFrom = jobDiscoveryYear[title] || fieldYear;
       allJobs.push({
         field,
@@ -342,6 +354,7 @@ for (const [field, levels] of Object.entries(jobFields)) {
         base,
         reqEdu: edu,
         reqMajor: major,
+        reqFollowers: followers,
         tuitionAssistance: ['education', 'healthcare', 'law'].includes(field),
         availableFrom
       });
@@ -372,7 +385,9 @@ export function generateJobs() {
   const econ = game.economy;
   const count = econ === 'boom' ? 8 : econ === 'recession' ? 4 : 6;
   const mod = econ === 'boom' ? 1.2 : econ === 'recession' ? 0.8 : 1;
-  const jobPool = allJobs.filter(j => j.availableFrom <= game.year);
+  const jobPool = allJobs.filter(
+    j => j.availableFrom <= game.year && (!j.reqFollowers || j.reqFollowers <= game.followers)
+  );
   for (let i = 0; i < count && jobPool.length; i++) {
     const job = jobPool[rand(0, jobPool.length - 1)];
     const salary = Math.round((job.base + rand(-3000, 12000)) * mod);
@@ -381,6 +396,7 @@ export function generateJobs() {
       salary,
       reqEdu: job.reqEdu,
       reqMajor: job.reqMajor,
+      reqFollowers: job.reqFollowers,
       field: job.field,
       level: job.level,
       tuitionAssistance: job.tuitionAssistance


### PR DESCRIPTION
## Summary
- add follower-gated influencer field to job listings
- refresh job listings when followers increase through social media

## Testing
- `npm test` *(fails: Cannot find module '../actions.js'; Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68b96ac81fa8832aba77ac96c4c2ef45