### PR TITLE
feat: add daycare activity

### DIFF
--- a/activities/daycare.js
+++ b/activities/daycare.js
@@ -1,0 +1,41 @@
+import { game, addLog, applyAndSave } from '../state.js';
+import { clamp } from '../utils.js';
+
+const WEEKLY_FEE_PER_CHILD = 200;
+
+export function renderDaycare(container) {
+  game.children = game.children || [];
+  const wrap = document.createElement('div');
+
+  const cost = WEEKLY_FEE_PER_CHILD * game.children.length;
+
+  const btn = document.createElement('button');
+  btn.className = 'btn block';
+  btn.textContent = `Pay Daycare ($${cost}/week)`;
+  btn.disabled = game.money < cost;
+
+  btn.addEventListener('click', () => {
+    if (game.money < cost) {
+      applyAndSave(() => {
+        addLog('You cannot afford daycare.', 'family');
+      });
+      return;
+    }
+    applyAndSave(() => {
+      game.money -= cost;
+      game.jobPerformance = clamp(game.jobPerformance + 5);
+      addLog('Daycare helped you focus at work. (+Performance)', 'job');
+    });
+  });
+
+  wrap.appendChild(btn);
+
+  const note = document.createElement('div');
+  note.className = 'muted';
+  note.style.marginTop = '8px';
+  note.textContent = 'Reliable daycare boosts job performance.';
+  wrap.appendChild(note);
+
+  container.appendChild(wrap);
+}
+

--- a/renderers/activities.js
+++ b/renderers/activities.js
@@ -1,4 +1,5 @@
 import { openWindow } from '../windowManager.js';
+import { game } from '../state.js';
 
 function openActivity(id, title, modulePath, exportName) {
   openWindow(id, title, async (container, win) => {
@@ -22,6 +23,7 @@ const ACTIVITIES_CATEGORIES = {
   ],
   'Family & Relationships': [
     'Adoption',
+    'Daycare',
     'Fertility',
     'Love',
     'Pets',
@@ -64,6 +66,7 @@ const ACTIVITY_RENDERERS = {
   Casino: () => openActivity('casino', 'Casino', '../activities/casino.js', 'renderCasino'),
   Gamble: () => openActivity('gamble', 'Gamble', '../activities/gamble.js', 'renderGamble'),
   Adoption: () => openActivity('adoption', 'Adoption', '../activities/adoption.js', 'renderAdoption'),
+  Daycare: () => openActivity('daycare', 'Daycare', '../activities/daycare.js', 'renderDaycare'),
   Fertility: () => openActivity('fertility', 'Fertility', '../activities/fertility.js', 'renderFertility'),
   Lottery: () => openActivity('lottery', 'Lottery', '../activities/lottery.js', 'renderLottery'),
   'Movie Theater': () => openActivity('movieTheater', 'Movie Theater', '../activities/movieTheater.js', 'renderMovieTheater'),
@@ -106,6 +109,12 @@ export function renderActivities(container) {
     wrap.appendChild(head);
 
     for (const item of items) {
+      if (
+        item === 'Daycare' &&
+        (!game.job || !game.children || game.children.length === 0)
+      ) {
+        continue;
+      }
       const btn = document.createElement('button');
       btn.className = 'btn';
       btn.textContent = item;


### PR DESCRIPTION
## Summary
- add new daycare activity that charges per-child weekly fees and boosts job performance
- show daycare option only when the player has a job and children

## Testing
- `npm test` *(fails: Cannot find module '../actions.js' and 3 other suites)*

------
https://chatgpt.com/codex/tasks/task_e_68b96abaeadc832aa89b3b80608aae8e