### PR TITLE
Fix syntax and service worker registration issues

### DIFF
--- a/renderers/activities.js
+++ b/renderers/activities.js
@@ -108,7 +108,7 @@ const ACTIVITY_RENDERERS = {
   Pets: () => openActivity('pets', 'Pets', '../activities/pets.js', 'renderPets'),
   Shopping: () => openActivity('shopping', 'Shopping', '../activities/shopping.js', 'renderShopping'),
   'Car Dealership': () => openActivity('carDealership', 'Car Dealership', '../activities/carDealership.js', 'renderCarDealership'),
-  'Car Maintenance': () => openActivity('carMaintenance', 'Car Maintenance', '../activities/carMaintenance.js', 'renderCarMaintenance')
+  'Car Maintenance': () => openActivity('carMaintenance', 'Car Maintenance', '../activities/carMaintenance.js', 'renderCarMaintenance'),
   Charity: () => openActivity('charity', 'Charity', '../activities/charity.js', 'renderCharity')
 };
 

--- a/script.js
+++ b/script.js
@@ -15,7 +15,7 @@ import { renderSettings } from './renderers/settings.js';
 
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('service-worker.js')
+    navigator.serviceWorker.register('service-worker.js', { type: 'module' })
       .catch(err => {
         console.error('SW registration failed', err);
         addLog('Service worker registration failed.', 'general');


### PR DESCRIPTION
## Summary
- fix typo in activities renderer causing missing comma before Charity
- register service worker as module to allow `export` syntax

## Testing
- `npm test 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68b97b161638832a8debafa06c5ccae3