### PR TITLE
Ensure log tab text fills window height

### DIFF
--- a/components.css
+++ b/components.css
@@ -56,7 +56,17 @@
 .jobs .job{ padding:10px 10px; border:1px solid var(--stroke); border-radius: 10px; margin:8px 0; display:flex; justify-content:space-between; align-items:center; cursor:pointer; }
 .jobs .job:hover{ border-color: rgba(255,255,255,.35); }
 
-.log{ height: 260px; overflow:auto; padding-right: 6px; }
+.log-container {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.log-container .log{
+  flex: 1;
+  overflow: auto;
+  padding-right: 6px;
+}
 .log .entry{ padding: 6px 8px; border-radius: 8px; border:1px solid var(--stroke); background: rgba(255,255,255,.04); margin: 6px 0; }
 .log time{ color: var(--muted); font-size: .85rem; }
 

--- a/renderers/log.js
+++ b/renderers/log.js
@@ -1,6 +1,7 @@
 import { game, addLog } from '../state.js';
 
 export function renderLog(container) {
+  container.classList.add('log-container');
   const categories = Array.from(new Set(game.log.map(l => l.category || 'general')));
   const select = document.createElement('select');
   const allOpt = document.createElement('option');


### PR DESCRIPTION
## Summary
- Allow the Log window to use a flex layout so its entries occupy the entire window content
- Remove fixed height on log entries container so it grows with the window

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9829d0ab4832a8da1424b9b844839