### PR TITLE
fix: ensure action buttons respond

### DIFF
--- a/renderers/actions.js
+++ b/renderers/actions.js
@@ -9,6 +9,7 @@ export function renderActions(container) {
   const mk = (text, fn, disabled = false) => {
     const b = document.createElement('button');
     b.className = 'btn';
+    b.type = 'button';
     b.textContent = text;
     b.disabled = disabled;
     b.addEventListener('click', fn);


### PR DESCRIPTION
## Summary
- prevent Action window buttons from acting like form submits

## Testing
- `/usr/bin/npm test` *(fails: /usr/bin/npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b9986052a8832abdbeb330fa64c29f