### PR TITLE
feat: toggle window transparency

### DIFF
--- a/components.css
+++ b/components.css
@@ -38,6 +38,19 @@
 .window.active{ opacity: 1; border-color: rgba(255,255,255,.55); box-shadow: var(--shadow-strong); }
 .window:not(.active) .titlebar{ background: linear-gradient(180deg, rgba(255,255,255,.05), rgba(255,255,255,.01)); }
 
+body.solid-windows .window{
+  background: var(--surface);
+  opacity: 1;
+}
+
+body.solid-windows .window .titlebar{
+  background: var(--surface);
+}
+
+body.solid-windows .window .content{
+  backdrop-filter: none;
+}
+
 .grid{ display: grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap: 10px; }
 .row{ display:flex; align-items:center; gap:8px; margin:6px 0; }
 .kpi{ display:flex; justify-content: space-between; align-items:center; gap:8px; margin:6px 0; }

--- a/partials/dock.html
+++ b/partials/dock.html
@@ -13,6 +13,7 @@
   <button data-toggle="help" role="button" aria-label="Open Help window">Help</button>
   <button data-toggle="newLife" role="button" aria-label="Start a new life">New Life</button>
   <button id="closeAll" role="button" aria-label="Close all windows">Close All</button>
-  <button id="themeToggle" title="Toggle theme" style="margin-left:auto" role="button" aria-label="Toggle theme" aria-pressed="false">🌙</button>
+  <button id="transparencyToggle" title="Toggle window transparency" style="margin-left:auto" role="button" aria-label="Toggle window transparency" aria-pressed="false">🔲</button>
+  <button id="themeToggle" title="Toggle theme" role="button" aria-label="Toggle theme" aria-pressed="false">🌙</button>
 </div>
 

--- a/renderers/settings.js
+++ b/renderers/settings.js
@@ -1,5 +1,5 @@
 import { saveGame, loadGame, newLife } from '../state.js';
-import { setTheme } from '../script.js';
+import { setTheme, setWindowTransparency } from '../script.js';
 
 export function renderSettings(container) {
   const wrap = document.createElement('div');
@@ -20,6 +20,12 @@ export function renderSettings(container) {
     mk('Toggle Theme', () => {
       const current = document.body.classList.contains('dark') ? 'light' : 'dark';
       setTheme(current);
+    })
+  );
+  wrap.appendChild(
+    mk('Toggle Window Transparency', () => {
+      const solid = !document.body.classList.contains('solid-windows');
+      setWindowTransparency(solid);
     })
   );
 

--- a/script.js
+++ b/script.js
@@ -59,6 +59,7 @@ await loadPartials();
 
 const dock = document.querySelector('.dock');
 const themeToggle = document.getElementById('themeToggle');
+const transparencyToggle = document.getElementById('transparencyToggle');
 
 if (dock) {
   const buttons = Array.from(dock.querySelectorAll('button'));
@@ -90,11 +91,26 @@ export function setTheme(theme) {
   localStorage.setItem('theme', theme);
 }
 
+export function setWindowTransparency(solid) {
+  document.body.classList.toggle('solid-windows', solid);
+  transparencyToggle.textContent = solid ? '⬛' : '🔲';
+  transparencyToggle.setAttribute('aria-pressed', String(solid));
+  localStorage.setItem('solidWindows', solid ? '1' : '0');
+}
+
 let theme = localStorage.getItem('theme');
 if (!theme) {
   theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 }
 setTheme(theme);
+
+let solid = localStorage.getItem('solidWindows') === '1';
+setWindowTransparency(solid);
+
+transparencyToggle.addEventListener('click', () => {
+  solid = !solid;
+  setWindowTransparency(solid);
+});
 
 const desktop = document.getElementById('desktop');
 const template = document.getElementById('window-template');

--- a/variables.css
+++ b/variables.css
@@ -1,5 +1,6 @@
 :root{
   --bg: radial-gradient(1200px 800px at 15% 10%, #1f2740, #0e1324 60%);
+  --surface: #1f2740;
   --glass: rgba(255,255,255,0.06);
   --glass-2: rgba(255,255,255,0.12);
   --stroke: rgba(255,255,255,0.15);
@@ -16,6 +17,7 @@
 
 body.dark{
   --bg: radial-gradient(1200px 800px at 15% 10%, #121625, #05070f 60%);
+  --surface: #121625;
   --glass: rgba(255,255,255,0.04);
   --glass-2: rgba(255,255,255,0.08);
   --stroke: rgba(255,255,255,0.1);


### PR DESCRIPTION
## Summary
- allow switching between glass and solid window backgrounds
- add dock toggle and settings option to persist window transparency preference

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b997e12ac4832a92dc4d59831158ac