### PR TITLE
Refactor theme utilities and fix service worker module

### DIFF
--- a/renderers/settings.js
+++ b/renderers/settings.js
@@ -1,5 +1,5 @@
 import { saveGame, loadGame, newLife } from '../state.js';
-import { setTheme, setWindowTransparency } from '../script.js';
+import { setTheme, setWindowTransparency } from '../ui.js';
 
 export function renderSettings(container) {
   const wrap = document.createElement('div');

--- a/script.js
+++ b/script.js
@@ -12,10 +12,11 @@ import { renderHelp } from './renderers/help.js';
 import { renderNewLife } from './renderers/newlife.js';
 import { renderAchievements } from './renderers/achievements.js';
 import { renderSettings } from './renderers/settings.js';
+import { setTheme, setWindowTransparency } from './ui.js';
 
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('service-worker.js', { type: 'module' })
+    navigator.serviceWorker.register('service-worker.js')
       .catch(err => {
         console.error('SW registration failed', err);
         addLog('Service worker registration failed.', 'general');
@@ -83,20 +84,6 @@ if (dock) {
   });
 }
 
-export function setTheme(theme) {
-  const isDark = theme === 'dark';
-  document.body.classList.toggle('dark', isDark);
-  themeToggle.textContent = isDark ? '☀️' : '🌙';
-  themeToggle.setAttribute('aria-pressed', String(isDark));
-  localStorage.setItem('theme', theme);
-}
-
-export function setWindowTransparency(solid) {
-  document.body.classList.toggle('solid-windows', solid);
-  transparencyToggle.textContent = solid ? '⬛' : '🔲';
-  transparencyToggle.setAttribute('aria-pressed', String(solid));
-  localStorage.setItem('solidWindows', solid ? '1' : '0');
-}
 
 let theme = localStorage.getItem('theme');
 if (!theme) {

--- a/service-worker-utils.js
+++ b/service-worker-utils.js
@@ -14,6 +14,7 @@ export const CORE_ASSETS = [
   'components.css',
   'variables.css',
   'script.js',
+  'ui.js',
   'actions.js',
   'state.js',
   'windowManager.js',

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,21 +1,62 @@
-import { CACHE_NAME, CORE_ASSETS, handleFetch } from './service-worker-utils.js';
+const CACHE_VERSION = 'v1';
+const CACHE_NAME = `tiny-life-cache-${CACHE_VERSION}`;
+const CORE_ASSETS = [
+  'index.html',
+  'base.css',
+  'components.css',
+  'variables.css',
+  'script.js',
+  'ui.js',
+  'actions.js',
+  'state.js',
+  'windowManager.js',
+  'utils.js',
+  'storyNet.js',
+  'partials/dock.html',
+  'partials/window-template.html',
+  'offline.html'
+];
 
-if (typeof self !== 'undefined') {
-  self.addEventListener('install', event => {
-    event.waitUntil(
-      caches.open(CACHE_NAME).then(cache => cache.addAll(CORE_ASSETS))
-    );
-  });
-
-  self.addEventListener('activate', event => {
-    event.waitUntil(
-      caches.keys().then(keys => Promise.all(
-        keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))
-      ))
-    );
-  });
-
-  self.addEventListener('fetch', event => {
-    event.respondWith(handleFetch(event.request));
-  });
+async function handleFetch(request) {
+  const cache = await caches.open(CACHE_NAME);
+  const cachedResponse = await cache.match(request);
+  try {
+    const networkResponse = await fetch(request);
+    if (networkResponse && networkResponse.ok) {
+      cache.put(request, networkResponse.clone());
+      const whitelist = new Set(
+        CORE_ASSETS.map(asset => new URL(asset, self.location).href)
+      );
+      whitelist.add(request.url);
+      cache.keys().then(keys => {
+        keys.forEach(key => {
+          if (!whitelist.has(key.url)) {
+            cache.delete(key);
+          }
+        });
+      });
+    }
+    return networkResponse;
+  } catch (_) {
+    return cachedResponse || caches.match('offline.html');
+  }
 }
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(CORE_ASSETS))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys => Promise.all(
+      keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key))
+    ))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(handleFetch(event.request));
+});
+

--- a/ui.js
+++ b/ui.js
@@ -1,0 +1,21 @@
+export function setTheme(theme) {
+  const themeToggle = document.getElementById('themeToggle');
+  const isDark = theme === 'dark';
+  document.body.classList.toggle('dark', isDark);
+  if (themeToggle) {
+    themeToggle.textContent = isDark ? '☀️' : '🌙';
+    themeToggle.setAttribute('aria-pressed', String(isDark));
+  }
+  localStorage.setItem('theme', theme);
+}
+
+export function setWindowTransparency(solid) {
+  const transparencyToggle = document.getElementById('transparencyToggle');
+  document.body.classList.toggle('solid-windows', solid);
+  if (transparencyToggle) {
+    transparencyToggle.textContent = solid ? '⬛' : '🔲';
+    transparencyToggle.setAttribute('aria-pressed', String(solid));
+  }
+  localStorage.setItem('solidWindows', solid ? '1' : '0');
+}
+


### PR DESCRIPTION
## Summary
- move theme and transparency helpers into dedicated `ui.js`
- update settings and main script to use shared helpers
- rewrite service worker to avoid ES module imports and cache new asset

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b99e35ed0c832ab7e68130fdee1276