### PR TITLE
Decouple health from death

### DIFF
--- a/actions/ageUp.js
+++ b/actions/ageUp.js
@@ -1,4 +1,4 @@
-import { game, addLog, die, saveGame, applyAndSave, unlockAchievement } from '../state.js';
+import { game, addLog, saveGame, applyAndSave, unlockAchievement } from '../state.js';
 import { rand, clamp } from '../utils.js';
 import { tickJail } from '../jail.js';
 import { tickRelationships } from '../activities/love.js';
@@ -77,7 +77,8 @@ function randomEvent() {
       'You spent freely and cheered up. (-Money, +Happiness)'
     ]);
   }
-  if (!game.sick && rand(1, 100) <= 8) {
+  const illnessChance = 8 + Math.floor((100 - game.health) / 5);
+  if (!game.sick && rand(1, 100) <= illnessChance) {
     game.sick = true;
     addLog([
       'You caught a nasty flu. (See Doctor)',
@@ -191,10 +192,6 @@ export function ageUp() {
         'Age caught up; you passed away.',
         'Life ended peacefully in old age.'
       ], 'life');
-    }
-    if (game.health <= 0 && game.alive) {
-      game.alive = false;
-      die('Your health reached zero. You passed away.');
     }
     tickJail();
     tickRelationships();

--- a/actions/crime.js
+++ b/actions/crime.js
@@ -1,4 +1,4 @@
-import { game, addLog, die, saveGame, applyAndSave } from '../state.js';
+import { game, addLog, saveGame, applyAndSave } from '../state.js';
 import { rand, clamp } from '../utils.js';
 
 export function crime() {
@@ -54,9 +54,6 @@ export function crime() {
           `Injury followed a botched ${c.name} (-${dmg} Health).`,
           `Attempting ${c.name} caused harm (-${dmg} Health).`
         ], 'crime');
-        if (game.health <= 0) {
-          die('You died from your injuries.');
-        }
       }
     }
   });

--- a/renderers/stats.js
+++ b/renderers/stats.js
@@ -70,7 +70,7 @@ export function renderStats(container) {
   addRow('Illness', game.sick ? 'Sick' : '—');
   container.appendChild(top);
   container.appendChild(
-    makeKpi('Health', game.health, 'Impacts life expectancy and illness recovery')
+    makeKpi('Health', game.health, 'Affects illness risk and recovery speed')
   );
   container.appendChild(
     makeKpi('Happiness', game.happiness, 'Influences your decisions and mood')

--- a/tests/actions.ageUp.test.js
+++ b/tests/actions.ageUp.test.js
@@ -70,6 +70,32 @@ const { game: mockedGame } = await import('../state.js');
 const { triggerPeerPressure } = await import('../school.js');
 
 describe('ageUp', () => {
+  beforeEach(() => {
+    Object.assign(game, {
+      age: 4,
+      year: 2000,
+      health: 80,
+      happiness: 70,
+      smarts: 10,
+      money: 0,
+      job: { salary: 12000, title: 'Tester', experience: 0 },
+      jobPerformance: 50,
+      jobExperience: 0,
+      jobLevel: 'entry',
+      properties: [],
+      alive: true,
+      sick: false,
+      inJail: false,
+      maxAge: 100,
+      jobListings: [],
+      parents: {
+        mother: { age: 50, health: 80 },
+        father: { age: 52, health: 80 }
+      }
+    });
+    randCall = 0;
+  });
+
   test('increments age, pays salary, and applies age-based events', () => {
     ageUp();
     expect(mockedGame.age).toBe(5);
@@ -77,6 +103,12 @@ describe('ageUp', () => {
     expect(mockedGame.money).toBe(11000);
     expect(mockedGame.smarts).toBe(13);
     expect(triggerPeerPressure).toHaveBeenCalled();
+  });
+
+  test('health reaching zero does not end life', () => {
+    game.health = 0;
+    ageUp();
+    expect(mockedGame.alive).toBe(true);
   });
 });
 

--- a/tests/actions.crime.test.js
+++ b/tests/actions.crime.test.js
@@ -78,5 +78,19 @@ describe('crime', () => {
     expect(game.health).toBe(75);
     expect(game.money).toBe(0);
   });
+
+  test('injury reducing health to zero does not kill', () => {
+    game.health = 5;
+    randMock
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(10)
+      .mockReturnValueOnce(80)
+      .mockReturnValueOnce(10);
+
+    crime();
+
+    expect(game.health).toBe(0);
+    expect(die).not.toHaveBeenCalled();
+  });
 });
 


### PR DESCRIPTION
## Summary
- Remove health-based death mechanics; health now only influences illness chance
- Update stats display to describe illness risk instead of life expectancy
- Add tests for survival at zero health

## Testing
- `npm test` *(fails: Cannot find module 'jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_68b9a4e1fdd0832ab4fbac64246cd56c