### PR TITLE
Close windows and disable menu on death

### DIFF
--- a/state.js
+++ b/state.js
@@ -1,8 +1,11 @@
-import { refreshOpenWindows } from './windowManager.js';
+import { refreshOpenWindows, openWindow, closeAllWindows } from './windowManager.js';
 import { rand } from './utils.js';
 import { showEndScreen, hideEndScreen } from './endscreen.js';
 import { initBrokers } from './realestate.js';
 import { getFaker } from './utils/faker.js';
+import { renderNewLife } from './renderers/newlife.js';
+import { renderLog } from './renderers/log.js';
+import { renderCharacter } from './renderers/character.js';
 
 const faker = await getFaker();
 
@@ -19,6 +22,14 @@ export function storageAvailable() {
   } catch (e) {
     return false;
   }
+}
+
+function setDockButtonsDisabled(disabled) {
+  if (typeof document === 'undefined') return;
+  document.querySelectorAll('.dock button').forEach(btn => {
+    if (btn.id === 'themeToggle' || btn.id === 'transparencyToggle') return;
+    btn.disabled = disabled;
+  });
 }
 
 export const game = {
@@ -108,6 +119,11 @@ export function unlockAchievement(id, text) {
 export function die(reason) {
   game.alive = false;
   addLog(reason, 'life');
+  closeAllWindows();
+  openWindow('log', 'Log', renderLog);
+  openWindow('character', 'Character', renderCharacter);
+  openWindow('newLife', 'New Life', renderNewLife);
+  setDockButtonsDisabled(true);
   showEndScreen(game);
 }
 
@@ -162,6 +178,7 @@ export function newLife(genderInput, nameInput) {
   const currentYear = new Date().getFullYear();
   const startYear = rand(1900, currentYear);
   hideEndScreen();
+  setDockButtonsDisabled(false);
   localStorage.removeItem('gameState');
   let gender = genderInput?.trim();
   if (gender) {

--- a/tests/actions.ageUp.test.js
+++ b/tests/actions.ageUp.test.js
@@ -57,7 +57,8 @@ jest.unstable_mockModule('../school.js', () => ({
   enrollUniversity: jest.fn(),
   reEnrollHighSchool: jest.fn(),
   getGed: jest.fn(),
-  triggerPeerPressure: jest.fn()
+  triggerPeerPressure: jest.fn(),
+  eduName: jest.fn()
 }));
 jest.unstable_mockModule('../jobs.js', () => ({ tickJob: jest.fn(), adjustJobPerformance: jest.fn() }));
 jest.unstable_mockModule('../utils/weather.js', () => ({

--- a/tests/actions.health.test.js
+++ b/tests/actions.health.test.js
@@ -45,7 +45,8 @@ await jest.unstable_mockModule('../school.js', () => ({
   enrollCollege: jest.fn(),
   enrollUniversity: jest.fn(),
   reEnrollHighSchool: jest.fn(),
-  getGed: jest.fn()
+  getGed: jest.fn(),
+  eduName: jest.fn()
 }));
 
 await jest.unstable_mockModule('../jobs.js', () => ({

--- a/tests/jobs.performance.test.js
+++ b/tests/jobs.performance.test.js
@@ -1,7 +1,10 @@
 import { jest } from '@jest/globals';
 
 jest.unstable_mockModule('../windowManager.js', () => ({
-  refreshOpenWindows: jest.fn()
+  refreshOpenWindows: jest.fn(),
+  openWindow: jest.fn(),
+  closeWindow: jest.fn(),
+  closeAllWindows: jest.fn()
 }));
 
 jest.unstable_mockModule('../endscreen.js', () => ({

--- a/tests/school.test.js
+++ b/tests/school.test.js
@@ -25,7 +25,8 @@ global.window = { addEventListener: jest.fn() };
 jest.unstable_mockModule('../windowManager.js', () => ({
   refreshOpenWindows: jest.fn(),
   openWindow: jest.fn(),
-  closeWindow: jest.fn()
+  closeWindow: jest.fn(),
+  closeAllWindows: jest.fn()
 }));
 
 jest.unstable_mockModule('../endscreen.js', () => ({

--- a/tests/state.newLife.test.js
+++ b/tests/state.newLife.test.js
@@ -10,7 +10,10 @@ global.localStorage = {
 };
 
 jest.unstable_mockModule('../windowManager.js', () => ({
-  refreshOpenWindows: jest.fn()
+  refreshOpenWindows: jest.fn(),
+  openWindow: jest.fn(),
+  closeWindow: jest.fn(),
+  closeAllWindows: jest.fn()
 }));
 
 jest.unstable_mockModule('../endscreen.js', () => ({

--- a/tests/state.storage.test.js
+++ b/tests/state.storage.test.js
@@ -13,7 +13,10 @@ await jest.unstable_mockModule('../endscreen.js', () => ({
 }));
 
 await jest.unstable_mockModule('../windowManager.js', () => ({
-  refreshOpenWindows: () => {}
+  refreshOpenWindows: () => {},
+  openWindow: () => {},
+  closeWindow: () => {},
+  closeAllWindows: () => {}
 }));
 
 await jest.unstable_mockModule('../realestate.js', () => ({


### PR DESCRIPTION
## Summary
- Close all game windows upon death, automatically opening Log, Character, and New Life windows
- Disable non-design dock buttons when deceased and re-enable them for a new life
- Adjust tests to mock new window manager functions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9c7e8d7a4832a892f866a5ccf5c1c