### PR TITLE
fix: guard transparency toggle

### DIFF
--- a/script.js
+++ b/script.js
@@ -94,10 +94,12 @@ setTheme(theme);
 let solid = localStorage.getItem('solidWindows') === '1';
 setWindowTransparency(solid);
 
-transparencyToggle.addEventListener('click', () => {
-  solid = !solid;
-  setWindowTransparency(solid);
-});
+if (transparencyToggle) {
+  transparencyToggle.addEventListener('click', () => {
+    solid = !solid;
+    setWindowTransparency(solid);
+  });
+}
 
 const desktop = document.getElementById('desktop');
 const template = document.getElementById('window-template');


### PR DESCRIPTION
## Summary
- handle missing transparency toggle button gracefully
- prevent runtime errors when setting window transparency

## Testing
- `npm test >/tmp/test.log && tail -n 20 /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_e_68b9e61657b0832a9f3c0d0534da355e