### PR TITLE
Skip caching for non-http requests in service worker

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -57,6 +57,8 @@ self.addEventListener('activate', event => {
 });
 
 self.addEventListener('fetch', event => {
-  event.respondWith(handleFetch(event.request));
+  if (event.request.url.startsWith('http')) {
+    event.respondWith(handleFetch(event.request));
+  }
 });
 


### PR DESCRIPTION
## Summary
- avoid caching requests with unsupported schemes to prevent runtime errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9ea0eeda4832a8c19adea9547e180