### PR TITLE
Add milestone achievements and central registry

### DIFF
--- a/actions/ageUp.js
+++ b/actions/ageUp.js
@@ -178,10 +178,19 @@ export function ageUp() {
           'job'
         );
       }
-      unlockAchievement('first-job', 'Got your first job.');
+      unlockAchievement('first-job');
     }
     if (game.properties.length > 0) {
-      unlockAchievement('first-property', 'Bought your first property.');
+      unlockAchievement('first-property');
+    }
+    if (game.money >= 1000000) {
+      unlockAchievement('millionaire');
+    }
+    if (game.age >= 100) {
+      unlockAchievement('centenarian');
+    }
+    if (game.education?.highest === 'phd') {
+      unlockAchievement('phd');
     }
     if (game.age >= game.maxAge) {
       game.alive = false;

--- a/realestate.js
+++ b/realestate.js
@@ -218,7 +218,7 @@ export function buyProperty(broker, listing) {
     'property'
   );
   if (game.properties.length === 1) {
-    unlockAchievement('first-property', 'Bought your first property.');
+    unlockAchievement('first-property');
   }
   saveGame();
   return true;

--- a/renderers/achievements.js
+++ b/renderers/achievements.js
@@ -1,19 +1,14 @@
-import { game } from '../state.js';
+import { game, ACHIEVEMENTS } from '../state.js';
 
 export function renderAchievements(container) {
   const list = document.createElement('div');
   list.className = 'achievements';
-  if (game.achievements.length === 0) {
+  for (const [id, text] of Object.entries(ACHIEVEMENTS)) {
+    const unlocked = game.achievements.some(a => a.id === id);
     const e = document.createElement('div');
-    e.textContent = 'No achievements unlocked yet.';
+    e.className = 'entry';
+    e.textContent = unlocked ? text : `${text} (locked)`;
     list.appendChild(e);
-  } else {
-    for (const a of game.achievements) {
-      const e = document.createElement('div');
-      e.className = 'entry';
-      e.textContent = a.text;
-      list.appendChild(e);
-    }
   }
   container.appendChild(list);
 }

--- a/renderers/jobs.js
+++ b/renderers/jobs.js
@@ -114,7 +114,7 @@ export function renderJobs(container) {
       game.jobLevel = job.level;
       game.jobSatisfaction = 70;
       addLog(`You became a ${job.title}. Salary $${job.salary.toLocaleString()}/yr.`, 'job');
-      unlockAchievement('first-job', 'Got your first job.');
+      unlockAchievement('first-job');
       refreshOpenWindows();
       saveGame();
     });

--- a/state.js
+++ b/state.js
@@ -13,6 +13,14 @@ function randomParent() {
   return { age: rand(20, 60), health: rand(60, 100) };
 }
 
+export const ACHIEVEMENTS = {
+  'first-job': 'Got your first job.',
+  'first-property': 'Bought your first property.',
+  millionaire: 'Earned $1,000,000.',
+  centenarian: 'Reached age 100.',
+  phd: 'Earned a PhD.'
+};
+
 export function storageAvailable() {
   try {
     const testKey = '__storage_test__';
@@ -104,10 +112,11 @@ export function addLog(text, category = 'general') {
   refreshOpenWindows();
 }
 
-export function unlockAchievement(id, text) {
+export function unlockAchievement(id) {
   if (game.achievements.some(a => a.id === id)) return;
+  const text = ACHIEVEMENTS[id] || id;
   game.achievements.push({ id, text });
-  addLog(`Achievement unlocked: ${text}`);
+  addLog(`Achievement unlocked: ${text}`, 'achievement');
   saveGame();
 }
 

--- a/tests/realestate.test.js
+++ b/tests/realestate.test.js
@@ -56,7 +56,7 @@ describe('real estate transactions', () => {
     expect(game.properties[0]).toMatchObject({ name: 'Test House', value: 500, rented: false, maintenanceCost: 5 });
     expect(broker.listings).toHaveLength(0);
     expect(mockAddLog).toHaveBeenCalledWith('You bought Test House from Test Broker for $500.', 'property');
-    expect(mockUnlockAchievement).toHaveBeenCalledWith('first-property', 'Bought your first property.');
+    expect(mockUnlockAchievement).toHaveBeenCalledWith('first-property');
   });
 
     test('sellProperty removes property and adds money', () => {


### PR DESCRIPTION
## Summary
- Centralize achievement definitions and logging
- Detect $1M balance, age 100, and PhD milestones in yearly aging
- Show full achievement list with locked state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9eb4dea64832a929305ff0692040b