### PR TITLE
Add health insurance and medical debt mechanics

### DIFF
--- a/actions/ageUp.js
+++ b/actions/ageUp.js
@@ -130,6 +130,26 @@ function randomEvent() {
       'Serendipity made you smarter. (+Smarts)'
     ]);
   }
+  if (rand(1, 150) === 1) {
+    const bill = rand(1000, 10000);
+    const coverage = game.insurancePlan ? game.insurancePlan.coverage : 0;
+    const finalBill = Math.floor(bill * (1 - coverage));
+    const covered = bill - finalBill;
+    let debt = 0;
+    if (game.money >= finalBill) {
+      game.money -= finalBill;
+    } else {
+      debt = finalBill - game.money;
+      game.medicalBills += debt;
+      game.money = 0;
+    }
+    addLog(
+      `You were hospitalized. Bill $${bill.toLocaleString()}${
+        covered > 0 ? ', insurance covered $' + covered.toLocaleString() : ''
+      }.${debt > 0 ? ` You couldn't pay $${debt.toLocaleString()}.` : ''}`,
+      'health'
+    );
+  }
 }
 
 export function ageUp() {

--- a/activities/health.js
+++ b/activities/health.js
@@ -1,0 +1,45 @@
+import { game, addLog, applyAndSave } from '../state.js';
+
+const PLANS = [
+  { name: 'Basic Plan', premium: 200, coverage: 0.5 },
+  { name: 'Premium Plan', premium: 500, coverage: 0.8 }
+];
+
+export function renderHealth(container) {
+  const wrap = document.createElement('div');
+  wrap.className = 'actions';
+
+  const mkBtn = plan => {
+    const b = document.createElement('button');
+    b.className = 'btn';
+    b.textContent = `${plan.name} ($${plan.premium}, ${Math.round(plan.coverage * 100)}% coverage)`;
+    b.disabled = game.insurancePlan && game.insurancePlan.name === plan.name;
+    b.addEventListener('click', () => {
+      if (game.money < plan.premium) {
+        applyAndSave(() => {
+          addLog(`Insurance plan costs $${plan.premium}. Not enough money.`, 'health');
+        });
+        return;
+      }
+      applyAndSave(() => {
+        game.money -= plan.premium;
+        game.insurancePlan = plan;
+        addLog(`You purchased ${plan.name}.`, 'health');
+      });
+    });
+    return b;
+  };
+
+  for (const plan of PLANS) {
+    wrap.appendChild(mkBtn(plan));
+  }
+
+  const note = document.createElement('div');
+  note.className = 'muted';
+  note.style.marginTop = '8px';
+  note.textContent = 'Insurance reduces hospitalization bills.';
+  wrap.appendChild(note);
+
+  container.appendChild(wrap);
+}
+

--- a/renderers/activities.js
+++ b/renderers/activities.js
@@ -57,7 +57,8 @@ const ACTIVITIES_CATEGORIES = {
     'Plastic Surgery',
     'Rehab',
     'Mind & Work',
-    'Meditation Retreat'
+    'Meditation Retreat',
+    'Health Insurance'
   ],
   'Travel & Community': [
     'Commune',
@@ -106,6 +107,7 @@ const ACTIVITY_ICONS = {
   Rehab: '🚭',
   'Mind & Work': '🧠',
   'Meditation Retreat': '🧘',
+  'Health Insurance': '📑',
   Commune: '🏘️',
   Emigrate: '✈️',
   Charity: '💝'
@@ -114,6 +116,12 @@ const ACTIVITY_ICONS = {
 const ACTIVITY_RENDERERS = {
   Love: () => openActivity('love', 'Love', '../activities/love.js', 'renderLove'),
   Doctor: () => openActivity('doctor', 'Doctor', '../activities/doctor.js', 'renderDoctor'),
+  'Health Insurance': () => openActivity(
+    'healthInsurance',
+    'Health Insurance',
+    '../activities/health.js',
+    'renderHealth'
+  ),
   'Plastic Surgery': () => openActivity('plasticSurgery', 'Plastic Surgery', '../activities/plasticSurgery.js', 'renderPlasticSurgery'),
   Casino: () => openActivity('casino', 'Casino', '../activities/casino.js', 'renderCasino'),
   Gamble: () => openActivity('gamble', 'Gamble', '../activities/gamble.js', 'renderGamble'),

--- a/renderers/stats.js
+++ b/renderers/stats.js
@@ -50,6 +50,7 @@ export function renderStats(container) {
   addRow('Money', `$${game.money.toLocaleString()}`);
   addRow('Economy', game.economy);
   addRow('Student Debt', `$${game.loanBalance.toLocaleString()}`);
+  addRow('Medical Debt', `$${game.medicalBills.toLocaleString()}`);
   const status = game.alive ? (game.inJail ? 'In Jail' : 'Alive') : 'Deceased';
   addRow('Status', status);
   if (game.job) {

--- a/state.js
+++ b/state.js
@@ -44,6 +44,8 @@ export const game = {
   money: 0,
   loanBalance: 0,
   insuranceLevel: 0,
+  insurancePlan: null,
+  medicalBills: 0,
   economy: 'normal',
   weather: 'sunny',
   loanInterestRate: 0.05,
@@ -161,6 +163,12 @@ export function loadGame() {
     if (!game.skills) {
       game.skills = { gambling: 0, racing: 0 };
     }
+    if (!('insurancePlan' in game)) {
+      game.insurancePlan = null;
+    }
+    if (typeof game.medicalBills !== 'number') {
+      game.medicalBills = 0;
+    }
   } catch {
     localStorage.removeItem('gameState');
     return false;
@@ -210,6 +218,8 @@ export function newLife(genderInput, nameInput) {
     money: 0,
     loanBalance: 0,
     insuranceLevel: 0,
+    insurancePlan: null,
+    medicalBills: 0,
     economy: 'normal',
     weather: 'sunny',
     loanInterestRate: 0.05,


### PR DESCRIPTION
## Summary
- add `insurancePlan` and `medicalBills` to game state with persistence defaults
- introduce Health Insurance activity to buy plans with premiums and coverage
- trigger random hospitalization bills reduced by coverage, track unpaid debt, and show medical debt in stats

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9eb2a7e98832a9919f2f1f28257a2