### PR TITLE
Add business ventures and entrepreneurial achievements

### DIFF
--- a/actions/ageUp.js
+++ b/actions/ageUp.js
@@ -3,6 +3,7 @@ import { rand, clamp } from '../utils.js';
 import { tickJail } from '../jail.js';
 import { tickRelationships } from '../activities/love.js';
 import { tickRealEstate } from '../realestate.js';
+import { tickBusinesses } from '../activities/business.js';
 import * as school from '../school.js';
 const { advanceSchool, accrueStudentLoanInterest } = school;
 import { tickJob } from '../jobs.js';
@@ -163,6 +164,7 @@ export function ageUp() {
     tickEconomy();
     weekendEvent();
     tickRealEstate();
+    tickBusinesses();
     if (game.job) {
       game.jobExperience += 1;
       const next = promotionOrder[game.jobLevel];

--- a/activities/business.js
+++ b/activities/business.js
@@ -1,0 +1,56 @@
+import { game, addLog, applyAndSave, unlockAchievement } from '../state.js';
+import { rand } from '../utils.js';
+
+export function renderBusiness(container) {
+  const wrap = document.createElement('div');
+
+  const startBtn = document.createElement('button');
+  startBtn.className = 'btn';
+  startBtn.textContent = 'Start Business';
+  startBtn.addEventListener('click', () => {
+    const cost = rand(5000, 20000);
+    if (game.money < cost) {
+      applyAndSave(() => {
+        addLog('Not enough money to start a business.', 'business');
+      });
+      return;
+    }
+    applyAndSave(() => {
+      game.money -= cost;
+      const biz = {
+        name: 'Business',
+        startupCost: cost,
+        revenue: rand(8000, 30000),
+        expenses: rand(4000, 15000),
+        employees: rand(1, 10),
+        profit: 0
+      };
+      game.businesses.push(biz);
+      addLog(`Started a business for $${cost.toLocaleString()}.`, 'business');
+      if (game.businesses.length === 1) {
+        unlockAchievement('first-business', 'Started your first business.');
+      }
+    });
+  });
+
+  wrap.appendChild(startBtn);
+  container.appendChild(wrap);
+}
+
+export function tickBusinesses() {
+  for (const biz of game.businesses) {
+    const annualCost = biz.expenses * biz.employees;
+    const profit = biz.revenue - annualCost;
+    game.money += profit;
+    biz.profit += profit;
+    addLog(
+      `Business ${biz.name} ${profit >= 0 ? 'earned' : 'lost'} $${Math.abs(profit).toLocaleString()}.`,
+      'business'
+    );
+  }
+  const total = game.businesses.reduce((sum, b) => sum + b.profit, 0);
+  if (total >= 100000) {
+    unlockAchievement('business-tycoon', 'Earned $100k in business profits.');
+  }
+}
+

--- a/renderers/activities.js
+++ b/renderers/activities.js
@@ -63,7 +63,8 @@ const ACTIVITIES_CATEGORIES = {
     'Commune',
     'Emigrate',
     'Charity'
-  ]
+  ],
+  'Business & Finance': ['Business']
 };
 
 const ACTIVITY_ICONS = {
@@ -108,7 +109,8 @@ const ACTIVITY_ICONS = {
   'Meditation Retreat': '🧘',
   Commune: '🏘️',
   Emigrate: '✈️',
-  Charity: '💝'
+  Charity: '💝',
+  Business: '💼'
 };
 
 const ACTIVITY_RENDERERS = {
@@ -154,7 +156,8 @@ const ACTIVITY_RENDERERS = {
   Shopping: () => openActivity('shopping', 'Shopping', '../activities/shopping.js', 'renderShopping'),
   'Car Dealership': () => openActivity('carDealership', 'Car Dealership', '../activities/carDealership.js', 'renderCarDealership'),
   'Car Maintenance': () => openActivity('carMaintenance', 'Car Maintenance', '../activities/carMaintenance.js', 'renderCarMaintenance'),
-  Charity: () => openActivity('charity', 'Charity', '../activities/charity.js', 'renderCharity')
+  Charity: () => openActivity('charity', 'Charity', '../activities/charity.js', 'renderCharity'),
+  Business: () => openActivity('business', 'Business', '../activities/business.js', 'renderBusiness')
 };
 
 export function renderActivities(container) {

--- a/state.js
+++ b/state.js
@@ -53,6 +53,7 @@ export const game = {
   properties: [],
   cars: [],
   portfolio: [],
+  businesses: [],
   job: null,
   jobSatisfaction: 50,
   jobPerformance: 50,
@@ -161,6 +162,9 @@ export function loadGame() {
     if (!game.skills) {
       game.skills = { gambling: 0, racing: 0 };
     }
+    if (!game.businesses) {
+      game.businesses = [];
+    }
   } catch {
     localStorage.removeItem('gameState');
     return false;
@@ -219,6 +223,7 @@ export function newLife(genderInput, nameInput) {
     properties: [],
     cars: [],
     portfolio: [],
+    businesses: [],
     job: null,
     jobSatisfaction: 50,
     jobPerformance: 50,

--- a/tests/actions.ageUp.test.js
+++ b/tests/actions.ageUp.test.js
@@ -12,6 +12,7 @@ const game = {
   jobExperience: 0,
   jobLevel: 'entry',
   properties: [],
+  businesses: [],
   alive: true,
   sick: false,
   inJail: false,
@@ -49,6 +50,7 @@ jest.unstable_mockModule('../jail.js', () => ({ tickJail: jest.fn() }));
 jest.unstable_mockModule('../activities/love.js', () => ({ tickRelationships: jest.fn() }));
 jest.unstable_mockModule('../actions/elderCare.js', () => ({ tickParents: jest.fn() }));
 jest.unstable_mockModule('../realestate.js', () => ({ tickRealEstate: jest.fn() }));
+jest.unstable_mockModule('../activities/business.js', () => ({ tickBusinesses: jest.fn() }));
 jest.unstable_mockModule('../school.js', () => ({
   advanceSchool: jest.fn(),
   accrueStudentLoanInterest: jest.fn(),
@@ -84,6 +86,7 @@ describe('ageUp', () => {
       jobExperience: 0,
       jobLevel: 'entry',
       properties: [],
+      businesses: [],
       alive: true,
       sick: false,
       inJail: false,


### PR DESCRIPTION
## Summary
- add Business activity to launch ventures, track revenue/expenses and unlock achievements
- extend game state with persistent `businesses` array and yearly profit processing
- update age progression and activity menu to include business profits and access

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9eb210d04832aaa4eed114f79b057