### PR TITLE
Add gym activity and fitness skill

### DIFF
--- a/actions/ageUp.js
+++ b/actions/ageUp.js
@@ -130,6 +130,18 @@ function randomEvent() {
       'Serendipity made you smarter. (+Smarts)'
     ]);
   }
+  if (rand(1, 40) === 1) {
+    addLog(
+      [
+        'You feel like you should exercise more.',
+        'A friend suggests you hit the gym.',
+        'Your body is craving a workout.',
+        'Maybe join a gym to stay in shape.',
+        'It might be time to work out.'
+      ],
+      'health'
+    );
+  }
 }
 
 export function ageUp() {

--- a/activities/gym.js
+++ b/activities/gym.js
@@ -1,0 +1,55 @@
+import { game, addLog, applyAndSave } from '../state.js';
+import { clamp, rand } from '../utils.js';
+
+export function renderGym(container) {
+  const head = document.createElement('div');
+  head.className = 'muted';
+  head.textContent = 'Build your body and looks at the gym.';
+  container.appendChild(head);
+
+  const workBtn = document.createElement('button');
+  workBtn.className = 'btn';
+  workBtn.textContent = 'Work Out';
+  workBtn.addEventListener('click', () => {
+    applyAndSave(() => {
+      const bonus = Math.floor(game.skills.fitness / 5);
+      const healthGain = rand(2, 5) + bonus;
+      const looksGain = rand(1, 3) + Math.floor(bonus / 2);
+      game.health = clamp(game.health + healthGain);
+      game.looks = clamp(game.looks + looksGain);
+      game.skills.fitness += 1;
+      addLog(
+        `You worked out. +${healthGain} Health, +${looksGain} Looks.`,
+        'health'
+      );
+    });
+  });
+  container.appendChild(workBtn);
+
+  const joinBtn = document.createElement('button');
+  joinBtn.className = 'btn';
+  joinBtn.textContent = 'Join Gym ($50)';
+  joinBtn.addEventListener('click', () => {
+    if (game.money < 50) {
+      applyAndSave(() => {
+        addLog('Gym membership costs $50. Not enough money.', 'health');
+      });
+      return;
+    }
+    applyAndSave(() => {
+      game.money -= 50;
+      const bonus = Math.floor(game.skills.fitness / 3);
+      const healthGain = rand(4, 8) + bonus;
+      const looksGain = rand(2, 5) + Math.floor(bonus / 2);
+      game.health = clamp(game.health + healthGain);
+      game.looks = clamp(game.looks + looksGain);
+      game.skills.fitness += 2;
+      addLog(
+        `You joined a gym. +${healthGain} Health, +${looksGain} Looks.`,
+        'health'
+      );
+    });
+  });
+  container.appendChild(joinBtn);
+}
+

--- a/renderers/activities.js
+++ b/renderers/activities.js
@@ -53,6 +53,7 @@ const ACTIVITIES_CATEGORIES = {
     'Will & Testament'
   ],
   'Health & Self-Improvement': [
+    'Gym',
     'Doctor',
     'Plastic Surgery',
     'Rehab',
@@ -101,6 +102,7 @@ const ACTIVITY_ICONS = {
   Lawsuit: '⚖️',
   Licenses: '📜',
   'Will & Testament': '📝',
+  Gym: '🏋️',
   Doctor: '🩺',
   'Plastic Surgery': '💉',
   Rehab: '🚭',
@@ -113,6 +115,7 @@ const ACTIVITY_ICONS = {
 
 const ACTIVITY_RENDERERS = {
   Love: () => openActivity('love', 'Love', '../activities/love.js', 'renderLove'),
+  Gym: () => openActivity('gym', 'Gym', '../activities/gym.js', 'renderGym'),
   Doctor: () => openActivity('doctor', 'Doctor', '../activities/doctor.js', 'renderDoctor'),
   'Plastic Surgery': () => openActivity('plasticSurgery', 'Plastic Surgery', '../activities/plasticSurgery.js', 'renderPlasticSurgery'),
   Casino: () => openActivity('casino', 'Casino', '../activities/casino.js', 'renderCasino'),

--- a/state.js
+++ b/state.js
@@ -84,7 +84,8 @@ export const game = {
   alive: true,
   skills: {
     gambling: 0,
-    racing: 0
+    racing: 0,
+    fitness: 0
   },
   log: []
 };
@@ -159,7 +160,9 @@ export function loadGame() {
   try {
     Object.assign(game, JSON.parse(data));
     if (!game.skills) {
-      game.skills = { gambling: 0, racing: 0 };
+      game.skills = { gambling: 0, racing: 0, fitness: 0 };
+    } else if (game.skills.fitness === undefined) {
+      game.skills.fitness = 0;
     }
   } catch {
     localStorage.removeItem('gameState');
@@ -250,7 +253,8 @@ export function newLife(genderInput, nameInput) {
     alive: true,
     skills: {
       gambling: 0,
-      racing: 0
+      racing: 0,
+      fitness: 0
     },
     log: []
   });


### PR DESCRIPTION
## Summary
- add Gym activity offering workouts and memberships to boost health and looks
- track new fitness skill to enhance workout gains and persist across saves
- occasionally remind players to exercise during age ups

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9eb160664832abe604ec0d5c18839