### PR TITLE
Add child system and parenting actions

### DIFF
--- a/actions/ageUp.js
+++ b/actions/ageUp.js
@@ -163,6 +163,22 @@ export function ageUp() {
     tickEconomy();
     weekendEvent();
     tickRealEstate();
+    if (game.children && game.children.length > 0) {
+      for (const child of game.children) {
+        child.age += 1;
+        child.happiness = clamp(child.happiness + rand(-2, 2));
+        if (child.age === 18) {
+          addLog([
+            'Your child became an adult.',
+            'One of your children turned 18.',
+            'You watched your child reach adulthood.',
+            'Eighteen years flew by—your child is grown.',
+            'Your child is now all grown up.'
+          ], 'family');
+          unlockAchievement('raise-child', 'Raised a child to adulthood.');
+        }
+      }
+    }
     if (game.job) {
       game.jobExperience += 1;
       const next = promotionOrder[game.jobLevel];

--- a/actions/family.js
+++ b/actions/family.js
@@ -1,4 +1,4 @@
-import { game, addLog, saveGame, applyAndSave } from '../state.js';
+import { game, addLog, saveGame, applyAndSave, unlockAchievement } from '../state.js';
 import { rand, clamp } from '../utils.js';
 
 export function hostFamilyGathering() {
@@ -25,6 +25,39 @@ export function hostFamilyGathering() {
       'You gathered the family and raised spirits. (+Relationship Happiness)',
       'A reunion with family warmed hearts. (+Relationship Happiness)'
     ], 'relationship');
+  });
+}
+
+export function haveChild() {
+  if (!game.alive) return;
+  applyAndSave(() => {
+    const child = { age: 0, happiness: 50 };
+    if (!game.children) game.children = [];
+    game.children.push(child);
+    addLog([
+      'You welcomed a new child into the world.',
+      'A child joined your family.',
+      'You became a parent to a newborn.'
+    ], 'family');
+    if (game.children.length === 1) {
+      unlockAchievement('first-child', 'Had your first child.');
+    }
+  });
+}
+
+export function spendTimeWithChild(index = 0) {
+  if (!game.alive || !game.children || !game.children[index]) return;
+  applyAndSave(() => {
+    const child = game.children[index];
+    child.happiness = clamp(child.happiness + rand(5, 15));
+    addLog([
+      'You spent quality time with your child. (+Child Happiness)',
+      'A fun day with your child lifted their spirits. (+Child Happiness)',
+      'Bonding with your child made them happier. (+Child Happiness)'
+    ], 'family');
+    if (child.happiness >= 90) {
+      unlockAchievement('happy-child', 'Raised a very happy child.');
+    }
   });
 }
 

--- a/actions/index.js
+++ b/actions/index.js
@@ -101,7 +101,7 @@ export { dropOut, enrollCollege, enrollUniversity, reEnrollHighSchool, getGed } 
 export { workExtra } from './job.js';
 export { seeDoctor } from './health.js';
 export { crime } from './crime.js';
-export { hostFamilyGathering } from './family.js';
+export { hostFamilyGathering, haveChild, spendTimeWithChild } from './family.js';
 export { buyCar, scheduleMaintenance } from './cars.js';
 export { renovateProperty } from './renovateProperty.js';
 export { ageUp } from './ageUp.js';

--- a/renderers/character.js
+++ b/renderers/character.js
@@ -3,10 +3,20 @@ import { game, applyAndSave, addLog } from '../state.js';
 export function renderCharacter(container) {
   const div = document.createElement('div');
   div.className = 'grid';
+  let childrenHTML = '';
+  if (game.children && game.children.length > 0) {
+    childrenHTML = '<div class="row"><strong>Children:</strong><ul>';
+    for (const [i, child] of game.children.entries()) {
+      const name = child.name ? child.name : `Child ${i + 1}`;
+      childrenHTML += `<li>${name} - Age ${child.age}, Happiness ${child.happiness}</li>`;
+    }
+    childrenHTML += '</ul></div>';
+  }
   div.innerHTML = `
         <div class="row"><strong>Name:</strong> <span class="char-name">${game.name}</span></div>
         <div class="row"><strong>Gender:</strong> <span>${game.gender}</span></div>
-        <div class="row"><strong>Location:</strong> <span>${game.city}, ${game.country}</span></div>`;
+        <div class="row"><strong>Location:</strong> <span>${game.city}, ${game.country}</span></div>
+        ${childrenHTML}`;
   const nameSpan = div.querySelector('.char-name');
   container.appendChild(div);
 

--- a/state.js
+++ b/state.js
@@ -62,6 +62,7 @@ export const game = {
   jobListings: [],
   jobListingsYear: null,
   relationships: [],
+  children: [],
   parents: {
     mother: randomParent(),
     father: randomParent()
@@ -161,6 +162,9 @@ export function loadGame() {
     if (!game.skills) {
       game.skills = { gambling: 0, racing: 0 };
     }
+    if (!game.children) {
+      game.children = [];
+    }
   } catch {
     localStorage.removeItem('gameState');
     return false;
@@ -228,6 +232,7 @@ export function newLife(genderInput, nameInput) {
     jobListings: [],
     jobListingsYear: null,
     relationships: [],
+    children: [],
     parents: {
       mother: randomParent(),
       father: randomParent()


### PR DESCRIPTION
## Summary
- Track children in game state with age and happiness
- Add actions to have children and spend time with them, unlocking achievements
- Show child details on character screen and age them annually

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9eb12e700832a86565e3ca713e219