### PR TITLE
feat: add save slot management

### DIFF
--- a/renderers/newlife.js
+++ b/renderers/newlife.js
@@ -1,8 +1,81 @@
-import { newLife } from '../state.js';
+import {
+  newLife,
+  listSlots,
+  setCurrentSlot,
+  deleteSlot,
+  saveGame,
+  loadGame,
+  getCurrentSlot
+} from '../state.js';
 import { openWindow, closeWindow } from '../windowManager.js';
 import { renderStats } from './stats.js';
 
+export function renderSlotManager(container) {
+  container.innerHTML = '';
+  const slots = listSlots();
+  const current = getCurrentSlot();
+  const wrap = document.createElement('div');
+  wrap.className = 'slot-manager';
+
+  if (slots.length) {
+    const select = document.createElement('select');
+    slots.forEach(s => {
+      const opt = document.createElement('option');
+      opt.value = s;
+      opt.textContent = s;
+      select.appendChild(opt);
+    });
+    if (current) select.value = current;
+    wrap.appendChild(select);
+
+    const loadBtn = document.createElement('button');
+    loadBtn.className = 'btn';
+    loadBtn.textContent = 'Load Slot';
+    loadBtn.addEventListener('click', () => {
+      setCurrentSlot(select.value);
+      loadGame(select.value);
+    });
+    wrap.appendChild(loadBtn);
+
+    const delBtn = document.createElement('button');
+    delBtn.className = 'btn';
+    delBtn.textContent = 'Delete Slot';
+    delBtn.addEventListener('click', () => {
+      deleteSlot(select.value);
+      renderSlotManager(container);
+    });
+    wrap.appendChild(delBtn);
+  } else {
+    const none = document.createElement('p');
+    none.textContent = 'No save slots found.';
+    wrap.appendChild(none);
+  }
+
+  const newInput = document.createElement('input');
+  newInput.type = 'text';
+  newInput.placeholder = 'New slot name';
+  wrap.appendChild(newInput);
+
+  const createBtn = document.createElement('button');
+  createBtn.className = 'btn';
+  createBtn.textContent = 'Create Slot';
+  createBtn.addEventListener('click', () => {
+    const name = newInput.value.trim();
+    if (!name) return;
+    setCurrentSlot(name);
+    saveGame();
+    renderSlotManager(container);
+  });
+  wrap.appendChild(createBtn);
+
+  container.appendChild(wrap);
+}
+
 export function renderNewLife(container) {
+  const slotArea = document.createElement('div');
+  renderSlotManager(slotArea);
+  container.appendChild(slotArea);
+
   const form = document.createElement('form');
   form.className = 'new-life';
   form.autocomplete = 'off';

--- a/renderers/settings.js
+++ b/renderers/settings.js
@@ -1,5 +1,6 @@
 import { saveGame, loadGame, newLife } from '../state.js';
 import { setTheme, setWindowTransparency } from '../ui.js';
+import { renderSlotManager } from './newlife.js';
 
 export function renderSettings(container) {
   const wrap = document.createElement('div');
@@ -12,6 +13,10 @@ export function renderSettings(container) {
     b.addEventListener('click', fn);
     return b;
   };
+
+  const slotWrap = document.createElement('div');
+  renderSlotManager(slotWrap);
+  wrap.appendChild(slotWrap);
 
   wrap.appendChild(mk('Save Game', saveGame));
   wrap.appendChild(mk('Load Game', loadGame));

--- a/script.js
+++ b/script.js
@@ -1,5 +1,5 @@
 import { initWindowManager, openWindow, toggleWindow, registerWindow, restoreOpenWindows, closeAllWindows, getRegisteredWindows } from './windowManager.js';
-import { newLife, loadGame, addLog } from './state.js';
+import { newLife, loadGame, addLog, getCurrentSlot, listSlots } from './state.js';
 import { renderStats } from './renderers/stats.js';
 import { renderActions } from './renderers/actions.js';
 import { renderLog } from './renderers/log.js';
@@ -178,7 +178,15 @@ themeToggle.addEventListener('click', () => {
   setTheme(theme);
 });
 
-if (!loadGame()) {
+const activeSlot = getCurrentSlot();
+const slots = listSlots();
+if (activeSlot) {
+  if (!loadGame(activeSlot)) {
+    openWindow('newLife', 'New Life', renderNewLife);
+  }
+} else if (slots.length) {
+  openWindow('settings', 'Settings', renderSettings);
+} else {
   openWindow('newLife', 'New Life', renderNewLife);
 }
 openWindowById('stats');


### PR DESCRIPTION
## Summary
- add persistent save slots and update save/load logic
- provide slot selection UI in Settings and New Life windows
- prompt players to choose or create a slot on startup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9eb55b080832aaa936c1779d9d03d