### PR TITLE
Add parole system and prison activities

### DIFF
--- a/actions/crime.js
+++ b/actions/crime.js
@@ -13,6 +13,21 @@ export function crime() {
     saveGame();
     return;
   }
+  if (game.onParole) {
+    game.onParole = false;
+    delete game.paroleYears;
+    game.inJail = true;
+    game.jailYears = rand(1, 3);
+    addLog([
+      `Parole violation! Back to jail for ${game.jailYears} year(s).`,
+      `You broke parole and received ${game.jailYears} year(s) in jail.`,
+      `Parole terms violated—${game.jailYears} year(s) behind bars.`,
+      `Caught breaching parole; ${game.jailYears} year(s) added in jail.`,
+      `Parole slip-up landed you ${game.jailYears} year(s) in jail.`
+    ], 'crime');
+    saveGame();
+    return;
+  }
   applyAndSave(() => {
     const crimes = [
       { name: 'Pickpocket', risk: 12, reward: [50, 180] },

--- a/activities/prison.js
+++ b/activities/prison.js
@@ -1,0 +1,57 @@
+import { game, addLog, applyAndSave } from '../state.js';
+import { clamp, rand } from '../utils.js';
+
+export function renderPrison(container) {
+  const wrap = document.createElement('div');
+  wrap.className = 'actions';
+
+  const mk = (text, fn) => {
+    const b = document.createElement('button');
+    b.className = 'btn';
+    b.textContent = text;
+    b.addEventListener('click', fn);
+    return b;
+  };
+
+  wrap.appendChild(
+    mk('Exercise in Yard', () => {
+      applyAndSave(() => {
+        if (!game.inJail) {
+          addLog('You are not in jail.', 'crime');
+          return;
+        }
+        const health = rand(1, 3);
+        const happy = rand(0, 2);
+        game.health = clamp(game.health + health);
+        game.happiness = clamp(game.happiness + happy);
+        addLog(
+          `You exercised in the yard. +${health} Health${happy ? `, +${happy} Happiness` : ''}.`,
+          'crime'
+        );
+      });
+    })
+  );
+
+  wrap.appendChild(
+    mk('Study in Cell', () => {
+      applyAndSave(() => {
+        if (!game.inJail) {
+          addLog('You are not in jail.', 'crime');
+          return;
+        }
+        const smarts = rand(1, 4);
+        game.smarts = clamp(game.smarts + smarts);
+        addLog(`You studied in your cell. +${smarts} Smarts.`, 'crime');
+      });
+    })
+  );
+
+  const note = document.createElement('div');
+  note.className = 'muted';
+  note.style.marginTop = '8px';
+  note.textContent = 'Limited options while incarcerated.';
+  wrap.appendChild(note);
+
+  container.appendChild(wrap);
+}
+

--- a/jail.js
+++ b/jail.js
@@ -1,19 +1,52 @@
 import { game, addLog, saveGame } from './state.js';
+import { rand } from './utils.js';
 
 export function tickJail() {
-  if (!game.inJail) return;
-  if (typeof game.jailYears !== 'number') game.jailYears = 1;
-  game.jailYears -= 1;
-  if (game.jailYears <= 0) {
-    game.inJail = false;
-    delete game.jailYears;
-    addLog([
-      'You were released from jail.',
-      'Freedom at last—you left jail.',
-      'Your jail time ended and you walked free.',
-      'The prison gates opened; you\'re out.',
-      'You served your sentence and were released.'
-    ], 'crime');
+  if (game.inJail) {
+    if (typeof game.jailYears !== 'number') game.jailYears = 1;
+    game.jailYears -= 1;
+    const parole = game.jailYears > 0 && rand(1, 100) <= 20;
+    if (game.jailYears <= 0 || parole) {
+      game.inJail = false;
+      delete game.jailYears;
+      if (parole) {
+        game.onParole = true;
+        game.paroleYears = rand(1, 3);
+        addLog([
+          `You were released on parole for ${game.paroleYears} year(s).`,
+          `Conditional release granted: ${game.paroleYears} year(s) on parole.`,
+          `Paroled with ${game.paroleYears} year(s) to stay clean.`,
+          `Early release came with ${game.paroleYears} year(s) of parole.`,
+          `${game.paroleYears} year(s) of parole accompany your release.`
+        ], 'crime');
+      } else {
+        addLog([
+          'You were released from jail.',
+          'Freedom at last—you left jail.',
+          'Your jail time ended and you walked free.',
+          'The prison gates opened; you\'re out.',
+          'You served your sentence and were released.'
+        ], 'crime');
+      }
+    }
+    saveGame();
+    return;
   }
-  saveGame();
+  if (game.onParole) {
+    if (typeof game.paroleYears !== 'number') game.paroleYears = 1;
+    game.paroleYears -= 1;
+    if (game.paroleYears <= 0) {
+      game.onParole = false;
+      delete game.paroleYears;
+      addLog([
+        'You completed your parole.',
+        'Parole period ended; you are fully free.',
+        'Your parole concluded successfully.',
+        'Conditions met: parole finished.',
+        'Parole over—you\'re entirely free now.'
+      ], 'crime');
+    }
+    saveGame();
+  }
 }
+

--- a/renderers/activities.js
+++ b/renderers/activities.js
@@ -108,7 +108,8 @@ const ACTIVITY_ICONS = {
   'Meditation Retreat': '🧘',
   Commune: '🏘️',
   Emigrate: '✈️',
-  Charity: '💝'
+  Charity: '💝',
+  Prison: '🚔'
 };
 
 const ACTIVITY_RENDERERS = {
@@ -127,6 +128,7 @@ const ACTIVITY_RENDERERS = {
   Vacation: () => openActivity('vacation', 'Vacation', '../activities/vacation.js', 'renderVacation'),
   'Salon & Spa': () => openActivity('salonAndSpa', 'Salon & Spa', '../activities/salonAndSpa.js', 'renderSalonAndSpa'),
   Crime: () => openActivity('crime', 'Crime', '../activities/crime.js', 'renderCrime'),
+  Prison: () => openActivity('prison', 'Prison', '../activities/prison.js', 'renderPrison'),
   'Black Market': () => openActivity('blackMarket', 'Black Market', '../activities/blackMarket.js', 'renderBlackMarket'),
   Identity: () => openActivity('identity', 'Identity', '../activities/identity.js', 'renderIdentity'),
   Emigrate: () => openActivity('emigrate', 'Emigrate', '../activities/emigrate.js', 'renderEmigrate'),
@@ -161,7 +163,15 @@ export function renderActivities(container) {
   const wrap = document.createElement('div');
   wrap.className = 'actions';
 
+  const categories = {};
   for (const [name, items] of Object.entries(ACTIVITIES_CATEGORIES)) {
+    categories[name] = [...items];
+  }
+  if (game.inJail) {
+    categories['Crime & Legal'] = ['Prison', ...categories['Crime & Legal']];
+  }
+
+  for (const [name, items] of Object.entries(categories)) {
     const head = document.createElement('div');
     head.className = 'muted';
     head.style.margin = '8px 0 4px';

--- a/renderers/stats.js
+++ b/renderers/stats.js
@@ -50,8 +50,17 @@ export function renderStats(container) {
   addRow('Money', `$${game.money.toLocaleString()}`);
   addRow('Economy', game.economy);
   addRow('Student Debt', `$${game.loanBalance.toLocaleString()}`);
-  const status = game.alive ? (game.inJail ? 'In Jail' : 'Alive') : 'Deceased';
+  const status = game.alive
+    ? game.inJail
+      ? 'In Jail'
+      : game.onParole
+        ? 'On Parole'
+        : 'Alive'
+    : 'Deceased';
   addRow('Status', status);
+  if (game.onParole) {
+    addRow('Parole', `${game.paroleYears ?? 0} year(s)`);
+  }
   if (game.job) {
     const jobSpan = document.createElement('span');
     jobSpan.textContent = `${game.job.title} `;

--- a/state.js
+++ b/state.js
@@ -81,6 +81,7 @@ export const game = {
   country: '',
   sick: false,
   inJail: false,
+  onParole: false,
   alive: true,
   skills: {
     gambling: 0,

--- a/tests/actions.crime.test.js
+++ b/tests/actions.crime.test.js
@@ -2,7 +2,14 @@ import { jest } from '@jest/globals';
 
 const randMock = jest.fn();
 
-const game = { money: 0, health: 80, happiness: 50, inJail: false, jailYears: 0 };
+const game = {
+  money: 0,
+  health: 80,
+  happiness: 50,
+  inJail: false,
+  jailYears: 0,
+  onParole: false
+};
 const addLog = jest.fn();
 const saveGame = jest.fn();
 const die = jest.fn();
@@ -31,7 +38,14 @@ const { crime } = await import('../actions.js');
 
 describe('crime', () => {
   beforeEach(() => {
-    Object.assign(game, { money: 0, health: 80, happiness: 50, inJail: false, jailYears: 0 });
+    Object.assign(game, {
+      money: 0,
+      health: 80,
+      happiness: 50,
+      inJail: false,
+      jailYears: 0,
+      onParole: false
+    });
     randMock.mockReset();
   });
 


### PR DESCRIPTION
## Summary
- track parole status and conditional release from jail
- add prison activity with exercise and study options
- show parole in character stats and handle parole violations in crime

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9eb503f48832aa5886c02998b22d3