### PR TITLE
Add economy phases influencing jobs, assets, and investments

### DIFF
--- a/actions/ageUp.js
+++ b/actions/ageUp.js
@@ -6,7 +6,7 @@ import { tickRealEstate } from '../realestate.js';
 import * as school from '../school.js';
 const { advanceSchool, accrueStudentLoanInterest } = school;
 import { tickJob } from '../jobs.js';
-import { paySalary, tickEconomy } from './job.js';
+import { paySalary } from './job.js';
 import { weekendEvent } from './weekend.js';
 
 const promotionThresholds = { entry: 3, mid: 5 };
@@ -132,6 +132,20 @@ function randomEvent() {
   }
 }
 
+function tickEconomyPhase() {
+  game.economyPhaseYears -= 1;
+  if (game.economyPhaseYears <= 0) {
+    const phases = ['boom', 'normal', 'recession'];
+    const next = phases[rand(0, phases.length - 1)];
+    if (next !== game.economyPhase) {
+      game.economyPhase = next;
+      game.jobListings = [];
+      addLog(`The economy entered a ${next}.`, 'economy');
+    }
+    game.economyPhaseYears = rand(3, 7);
+  }
+}
+
 export function ageUp() {
   if (!game.alive) {
     addLog([
@@ -160,7 +174,7 @@ export function ageUp() {
     accrueStudentLoanInterest();
     randomEvent();
     tickJob();
-    tickEconomy();
+    tickEconomyPhase();
     weekendEvent();
     tickRealEstate();
     if (game.job) {

--- a/actions/job.js
+++ b/actions/job.js
@@ -60,18 +60,6 @@ export function paySalary() {
   }
 }
 
-export function tickEconomy() {
-  if (rand(1, 5) === 1) {
-    const states = ['boom', 'normal', 'recession'];
-    const next = states[rand(0, states.length - 1)];
-    if (next !== game.economy) {
-      game.economy = next;
-      game.jobListings = [];
-      addLog(`The economy shifted to a ${next}.`, 'economy');
-    }
-  }
-}
-
 export function workExtra() {
   if (!game.job) {
     addLog([

--- a/components.css
+++ b/components.css
@@ -84,6 +84,9 @@ body.solid-windows .window .content{
 .log time{ color: var(--muted); font-size: .85rem; }
 
 .badge{ display:inline-block; padding: 2px 8px; border-radius: 999px; border:1px solid var(--stroke); background: rgba(255,255,255,.06); font-size:.8rem; color: var(--muted); }
+.badge.boom{ background: var(--good); color: var(--surface); }
+.badge.recession{ background: var(--bad); color: var(--surface); }
+.badge.normal{ background: var(--accent); color: var(--surface); }
 
 #endscreen{
   position: fixed;

--- a/investment.js
+++ b/investment.js
@@ -30,13 +30,19 @@ export function updateInvestmentRisk(inv, risk) {
 
 export function calculateDividend(inv) {
   const tier = riskTiers[inv.risk];
-  return tier ? inv.amount * tier.dividendRate : 0;
+  if (!tier) return 0;
+  const phase = game.economyPhase;
+  const mod = phase === 'boom' ? 1.2 : phase === 'recession' ? 0.8 : 1;
+  return inv.amount * tier.dividendRate * mod;
 }
 
 export function calculateVolatility(inv) {
   const tier = riskTiers[inv.risk];
   if (!tier) return 0;
-  const change = inv.amount * (Math.random() * tier.volatility * 2 - tier.volatility);
+  let change = inv.amount * (Math.random() * tier.volatility * 2 - tier.volatility);
+  const phase = game.economyPhase;
+  const mod = phase === 'boom' ? 1.1 : phase === 'recession' ? 1.3 : 1;
+  change *= mod;
   return Math.round(change);
 }
 

--- a/jobs.js
+++ b/jobs.js
@@ -394,9 +394,9 @@ export function generateJobs() {
       });
     }
   }
-  const econ = game.economy;
-  const count = econ === 'boom' ? 8 : econ === 'recession' ? 4 : 6;
-  const mod = econ === 'boom' ? 1.2 : econ === 'recession' ? 0.8 : 1;
+  const phase = game.economyPhase;
+  const count = phase === 'boom' ? 8 : phase === 'recession' ? 4 : 6;
+  const mod = phase === 'boom' ? 1.2 : phase === 'recession' ? 0.8 : 1;
   const jobPool = allJobs.filter(
     j => j.availableFrom <= game.year && (!j.reqMajor || j.reqMajor === game.major) && (!j.reqFollowers || j.reqFollowers <= game.followers)
   );

--- a/realestate.js
+++ b/realestate.js
@@ -273,7 +273,15 @@ export function repairProperty(prop, percent) {
 
 export function tickRealEstate() {
   for (const prop of game.properties) {
-    const factor = rand(95, 110) / 100;
+    let factor;
+    const phase = game.economyPhase;
+    if (phase === 'boom') {
+      factor = rand(105, 115) / 100;
+    } else if (phase === 'recession') {
+      factor = rand(85, 100) / 100;
+    } else {
+      factor = rand(95, 110) / 100;
+    }
     prop.value = Math.round(prop.value * factor);
     const tax = Math.round(prop.value * 0.01);
     game.money -= tax;

--- a/renderers/jobs.js
+++ b/renderers/jobs.js
@@ -20,7 +20,7 @@ export function renderJobs(container) {
     recession: 'Economy is in recession: fewer jobs and lower pay.',
     normal: 'Economy is stable.'
   };
-  econ.textContent = econMsg[game.economy];
+  econ.textContent = econMsg[game.economyPhase];
   container.appendChild(econ);
   if (game.job) {
     const perf = document.createElement('div');

--- a/renderers/stats.js
+++ b/renderers/stats.js
@@ -48,7 +48,10 @@ export function renderStats(container) {
   addRow('Year', game.year);
   addRow('Age', game.age);
   addRow('Money', `$${game.money.toLocaleString()}`);
-  addRow('Economy', game.economy);
+  const econ = document.createElement('span');
+  econ.className = `badge ${game.economyPhase}`;
+  econ.textContent = game.economyPhase;
+  addRow('Economy', econ);
   addRow('Student Debt', `$${game.loanBalance.toLocaleString()}`);
   const status = game.alive ? (game.inJail ? 'In Jail' : 'Alive') : 'Deceased';
   addRow('Status', status);

--- a/state.js
+++ b/state.js
@@ -44,7 +44,8 @@ export const game = {
   money: 0,
   loanBalance: 0,
   insuranceLevel: 0,
-  economy: 'normal',
+  economyPhase: 'normal',
+  economyPhaseYears: rand(3, 7),
   weather: 'sunny',
   loanInterestRate: 0.05,
   followers: 0,
@@ -161,6 +162,12 @@ export function loadGame() {
     if (!game.skills) {
       game.skills = { gambling: 0, racing: 0 };
     }
+    if (!game.economyPhase) {
+      game.economyPhase = 'normal';
+    }
+    if (!game.economyPhaseYears) {
+      game.economyPhaseYears = rand(3, 7);
+    }
   } catch {
     localStorage.removeItem('gameState');
     return false;
@@ -210,7 +217,8 @@ export function newLife(genderInput, nameInput) {
     money: 0,
     loanBalance: 0,
     insuranceLevel: 0,
-    economy: 'normal',
+    economyPhase: 'normal',
+    economyPhaseYears: rand(3, 7),
     weather: 'sunny',
     loanInterestRate: 0.05,
     followers: 0,

--- a/tests/jobs.generate.test.js
+++ b/tests/jobs.generate.test.js
@@ -19,7 +19,7 @@ function resetGame() {
   game.jobListingsYear = null;
 }
 
-describe('generateJobs economy effects', () => {
+describe('generateJobs economyPhase effects', () => {
   let randSpy;
   beforeEach(() => {
     randSpy = jest.spyOn(Math, 'random').mockReturnValue(0.5);
@@ -30,7 +30,7 @@ describe('generateJobs economy effects', () => {
     randSpy.mockRestore();
   });
   function gen(econ) {
-    game.economy = econ;
+    game.economyPhase = econ;
     game.jobListings = [];
     game.jobListingsYear = null;
     return generateJobs();
@@ -53,7 +53,7 @@ describe('generateJobs part-time', () => {
   beforeEach(() => {
     randSpy = jest.spyOn(Math, 'random').mockReturnValue(0.5);
     resetGame();
-    game.economy = 'normal';
+    game.economyPhase = 'normal';
     game.education.current = 'college';
   });
   afterEach(() => {


### PR DESCRIPTION
## Summary
- Track `economyPhase` and countdown in game state
- Randomly shift economy every few years and refresh job listings
- Scale job salaries, property values, and investment returns by phase with visual indicator in stats

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9eb1ba230832a8966a4abf2f83cdd