### PR TITLE
Add basic state machine

### DIFF
--- a/actions/ageUp.js
+++ b/actions/ageUp.js
@@ -1,4 +1,4 @@
-import { game, addLog, saveGame, applyAndSave, unlockAchievement } from '../state.js';
+import { game, addLog, saveGame, applyAndSave, unlockAchievement, die } from '../state.js';
 import { rand, clamp } from '../utils.js';
 import { tickJail } from '../jail.js';
 import { tickRelationships } from '../activities/love.js';
@@ -7,7 +7,7 @@ import { tickBusinesses } from '../activities/business.js';
 import * as school from '../school.js';
 const { advanceSchool, accrueStudentLoanInterest } = school;
 import { tickJob } from '../jobs.js';
-import { paySalary, tickEconomy } from './job.js';
+import { paySalary } from './job.js';
 import { calculateDividend } from '../investment.js';
 import { weekendEvent } from './weekend.js';
 
@@ -217,7 +217,6 @@ export function ageUp() {
     }
     const salaryIncome = paySalary();
     const dividendIncome = collectDividends();
-    paySalary();
     if (game.retired && game.pension > 0) {
       if (game.pensionFromSavings) {
         const amount = Math.min(game.pension, game.money);
@@ -297,16 +296,15 @@ export function ageUp() {
     if (game.education?.highest === 'phd') {
       unlockAchievement('phd');
     }
-    if (game.age >= game.maxAge) {
-      game.alive = false;
-      addLog([
-        'You died of old age.',
-        'Old age finally claimed you.',
-        'Your time came due to old age.',
-        'Age caught up; you passed away.',
-        'Life ended peacefully in old age.'
-      ], 'life');
-    }
+      if (game.age >= game.maxAge) {
+        die([
+          'You died of old age.',
+          'Old age finally claimed you.',
+          'Your time came due to old age.',
+          'Age caught up; you passed away.',
+          'Life ended peacefully in old age.'
+        ]);
+      }
     game.pets = game.pets || [];
     for (const pet of game.pets) {
       if (!pet.alive) continue;

--- a/renderers/stats.js
+++ b/renderers/stats.js
@@ -53,6 +53,7 @@ export function renderStats(container) {
   econ.textContent = game.economyPhase;
   addRow('Economy', econ);
   addRow('Student Debt', `$${game.loanBalance.toLocaleString()}`);
+  addRow('Medical Debt', `$${game.medicalBills.toLocaleString()}`);
   const status = game.alive
     ? game.inJail
       ? 'In Jail'
@@ -60,8 +61,6 @@ export function renderStats(container) {
         ? 'On Parole'
         : 'Alive'
     : 'Deceased';
-  addRow('Medical Debt', `$${game.medicalBills.toLocaleString()}`);
-  const status = game.alive ? (game.inJail ? 'In Jail' : 'Alive') : 'Deceased';
   addRow('Status', status);
   if (game.onParole) {
     addRow('Parole', `${game.paroleYears ?? 0} year(s)`);

--- a/tests/state.newLife.test.js
+++ b/tests/state.newLife.test.js
@@ -32,7 +32,7 @@ jest.unstable_mockModule('../realestate.js', () => {
   };
 });
 
-const { newLife, game } = await import('../state.js');
+const { newLife, game, lifeState } = await import('../state.js');
 const realestate = await import('../realestate.js');
 const { brokers, initBrokers } = realestate;
 
@@ -61,6 +61,7 @@ describe('newLife', () => {
     expect(game.achievements).toEqual([]);
     expect(brokers.length).toBeGreaterThan(0);
     expect(initBrokers).toHaveBeenCalled();
+    expect(lifeState.state).toBe('alive');
   });
 });
 

--- a/tests/stateMachine.test.js
+++ b/tests/stateMachine.test.js
@@ -1,0 +1,18 @@
+import { StateMachine } from '../utils/stateMachine.js';
+
+describe('StateMachine', () => {
+  test('transitions between states', () => {
+    const sm = new StateMachine('a', { a: { go: 'b' }, b: { reset: 'a' } });
+    expect(sm.state).toBe('a');
+    expect(sm.transition('go')).toBe(true);
+    expect(sm.state).toBe('b');
+    expect(sm.transition('reset')).toBe(true);
+    expect(sm.state).toBe('a');
+  });
+
+  test('rejects invalid transitions', () => {
+    const sm = new StateMachine('a', { a: { go: 'b' } });
+    expect(sm.transition('stop')).toBe(false);
+    expect(sm.state).toBe('a');
+  });
+});

--- a/utils/stateMachine.js
+++ b/utils/stateMachine.js
@@ -1,0 +1,17 @@
+export class StateMachine {
+  constructor(initial, transitions = {}) {
+    this.state = initial;
+    this.transitions = transitions;
+  }
+
+  can(event) {
+    const stateTransitions = this.transitions[this.state];
+    return stateTransitions && Object.prototype.hasOwnProperty.call(stateTransitions, event);
+  }
+
+  transition(event) {
+    if (!this.can(event)) return false;
+    this.state = this.transitions[this.state][event];
+    return true;
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable `StateMachine` utility
- wire player lifecycle into state machine and update death handling
- fix duplicate status declaration in stats renderer

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9f21cba98832abbaf1174241735b9