### PR TITLE
Avoid circular import for new life window

### DIFF
--- a/state.js
+++ b/state.js
@@ -4,7 +4,6 @@ import { StateMachine } from './utils/stateMachine.js';
 import { showEndScreen, hideEndScreen } from './endscreen.js';
 import { initBrokers } from './realestate.js';
 import { getFaker } from './utils/faker.js';
-import { renderNewLife } from './renderers/newlife.js';
 import { renderLog } from './renderers/log.js';
 import { renderCharacter } from './renderers/character.js';
 
@@ -197,7 +196,9 @@ export function die(reason) {
   closeAllWindows();
   openWindow('log', 'Log', renderLog);
   openWindow('character', 'Character', renderCharacter);
-  openWindow('newLife', 'New Life', renderNewLife);
+  import('./renderers/newlife.js').then(({ renderNewLife }) => {
+    openWindow('newLife', 'New Life', renderNewLife);
+  });
   setDockButtonsDisabled(true);
   showEndScreen(game);
 }


### PR DESCRIPTION
## Summary
- break circular dependency between `state.js` and `renderers/newlife.js`
- dynamically load `renderNewLife` when opening the New Life window to keep `deleteSlot` export intact

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9f6ad6cac832aabdffac34dc94dec