### PR TITLE
fix: delay new life form removal

### DIFF
--- a/renderers/newlife.js
+++ b/renderers/newlife.js
@@ -125,7 +125,8 @@ export function renderNewLife(container) {
     e.preventDefault();
     newLife(genderSelect.value, nameInput.value);
     openWindow('stats', 'Stats', renderStats);
-    closeWindow('newLife');
+    // Delay closing to allow extensions to process the submit event
+    setTimeout(() => closeWindow('newLife'), 0);
   });
 
   container.appendChild(form);


### PR DESCRIPTION
## Summary
- delay removal of new life form so browser extensions can process submit event

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba0dbaef60832a822a67fb41231557