### PR TITLE
Match real estate listings with job menu styling

### DIFF
--- a/components.css
+++ b/components.css
@@ -69,6 +69,26 @@ body.solid-windows .window .content{
 .jobs .job{ padding:10px 10px; border:1px solid var(--stroke); border-radius: 10px; margin:8px 0; display:flex; justify-content:space-between; align-items:center; cursor:pointer; }
 .jobs .job:hover{ border-color: rgba(255,255,255,.35); }
 
+.properties .property{
+  padding: 10px 10px;
+  border: 1px solid var(--stroke);
+  border-radius: 10px;
+  margin: 8px 0;
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+}
+.properties .property:hover{ border-color: rgba(255,255,255,.35); }
+.property-icon{
+  width: 24px;
+  height: 24px;
+  font-size: 20px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-right: 4px;
+}
+
 .log-container {
   display: flex;
   flex-direction: column;

--- a/renderers/realestate.js
+++ b/renderers/realestate.js
@@ -47,7 +47,7 @@ export function renderRealEstate(container) {
         icon.className = 'material-icons';
         icon.textContent = p.icon.icon;
       }
-      icon.style.marginRight = '4px';
+      icon.classList.add('property-icon');
       propBtn.appendChild(icon);
       let text = ` ${p.name} - Val $${p.value.toLocaleString()} - Cond ${p.condition}%`;
       if (p.mortgage) {
@@ -126,8 +126,11 @@ function renderBrokerListings(broker, container) {
     container.appendChild(none);
     return;
   }
+  const wrap = document.createElement('div');
+  wrap.className = 'properties';
   listings.forEach(l => {
-    const btn = document.createElement('button');
+    const row = document.createElement('div');
+    row.className = 'property';
     const icon = document.createElement(l.icon.type === 'fa' ? 'i' : 'span');
     if (l.icon.type === 'fa') {
       icon.className = `fa-solid ${l.icon.icon}`;
@@ -135,14 +138,17 @@ function renderBrokerListings(broker, container) {
       icon.className = 'material-icons';
       icon.textContent = l.icon.icon;
     }
-    icon.style.marginRight = '4px';
-    btn.appendChild(icon);
-    btn.appendChild(document.createTextNode(` ${l.name} - $${l.value.toLocaleString()}`));
-    btn.addEventListener('click', () => {
+    icon.classList.add('property-icon');
+    row.appendChild(icon);
+    const span = document.createElement('span');
+    span.textContent = ` ${l.name} - $${l.value.toLocaleString()}`;
+    row.appendChild(span);
+    row.addEventListener('click', () => {
       openWindow(`listing-${l.id}`, l.name, c => renderListingDetails(broker, l, c));
     });
-    container.appendChild(btn);
+    wrap.appendChild(row);
   });
+  container.appendChild(wrap);
 }
 
 function renderListingDetails(broker, listing, container) {


### PR DESCRIPTION
## Summary
- Style property listings using the same bordered layout as job menu entries
- Normalize property icons with a dedicated `.property-icon` class for consistent sizing

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68ba0f213b44832a8edb564c78e59ea6