### PR TITLE
Clear loading text after activity modules load

### DIFF
--- a/renderers/activities.js
+++ b/renderers/activities.js
@@ -4,8 +4,14 @@ import { game } from '../state.js';
 function openActivity(id, title, modulePath, exportName) {
   openWindow(id, title, async (container, win) => {
     container.textContent = 'Loading...';
-    const mod = await import(modulePath);
-    mod[exportName](container, win);
+    try {
+      const mod = await import(modulePath);
+      container.innerHTML = '';
+      mod[exportName](container, win);
+    } catch (err) {
+      container.textContent = 'Failed to load activity.';
+      console.error('Failed to load activity:', err);
+    }
   });
 }
 


### PR DESCRIPTION
## Summary
- Remove leftover `Loading...` text once activity modules are imported
- Show error message if an activity fails to load

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba12daa63c832ab3ac3e819004bc7f