### PR TITLE
Enable continuing a life as an existing child

### DIFF
--- a/renderers/newlife.js
+++ b/renderers/newlife.js
@@ -5,7 +5,9 @@ import {
   deleteSlot,
   saveGame,
   loadGame,
-  getCurrentSlot
+  getCurrentSlot,
+  continueAsChild,
+  game
 } from '../state.js';
 import { openWindow, closeWindow } from '../windowManager.js';
 import { renderStats } from './stats.js';
@@ -72,6 +74,28 @@ export function renderSlotManager(container) {
 }
 
 export function renderNewLife(container) {
+  if (game.children && game.children.length > 0) {
+    const choice = document.createElement('div');
+    const msg = document.createElement('p');
+    msg.textContent = 'Continue as one of your children:';
+    choice.appendChild(msg);
+    game.children.forEach((child, i) => {
+      const btn = document.createElement('button');
+      btn.className = 'btn block';
+      const name = child.name ? child.name : `Child ${i + 1}`;
+      btn.textContent = `${name} - Age ${child.age}`;
+      btn.addEventListener('click', () => {
+        continueAsChild(i);
+        openWindow('stats', 'Stats', renderStats);
+        setTimeout(() => closeWindow('newLife'), 0);
+      });
+      choice.appendChild(btn);
+    });
+    container.appendChild(choice);
+    const hr = document.createElement('hr');
+    container.appendChild(hr);
+  }
+
   const slotArea = document.createElement('div');
   renderSlotManager(slotArea);
   container.appendChild(slotArea);

--- a/state.js
+++ b/state.js
@@ -287,14 +287,15 @@ export function loadGame(slot = currentSlot) {
   return true;
 }
 
-export function newLife(genderInput, nameInput) {
+export function newLife(genderInput, nameInput, options = {}) {
 /**
  * Starts a new life, resetting the game state and prompting for basic info.
+ * Accepts optional overrides via the options parameter for generational play.
  * @returns {void}
  */
   lifeState.transition(lifeState.state === 'initial' ? 'start' : 'restart');
   const currentYear = new Date().getFullYear();
-  const startYear = rand(1900, currentYear);
+  const startYear = options.startYear ?? rand(1900, currentYear);
   hideEndScreen();
   setDockButtonsDisabled(false);
   if (currentSlot) {
@@ -329,10 +330,10 @@ export function newLife(genderInput, nameInput) {
   const country = faker.location.country();
   Object.assign(game, {
     year: startYear,
-    age: 0,
+    age: options.age ?? 0,
     maxAge: rand(80, 120),
     health: 80,
-    happiness: 70,
+    happiness: options.happiness ?? 70,
     smarts: 65,
     looks: 50,
     addiction: 0,
@@ -369,7 +370,7 @@ export function newLife(genderInput, nameInput) {
     jobListingsYear: null,
     relationships: [],
     children: [],
-    parents: {
+    parents: options.parents ?? {
       mother: randomParent(),
       father: randomParent()
     },
@@ -397,15 +398,30 @@ export function newLife(genderInput, nameInput) {
     log: []
   });
   initBrokers().then(refreshOpenWindows);
-  addLog([
-    'You were born. A new life begins.',
-    'Welcome to the world! A new journey starts.',
-    'A new life springs forth—you were just born.',
-    'You entered the world. The adventure begins.',
-    'A new life dawns as you are born.'
-  ], 'life');
+  if (!options.skipBirthLog) {
+    addLog([
+      'You were born. A new life begins.',
+      'Welcome to the world! A new journey starts.',
+      'A new life springs forth—you were just born.',
+      'You entered the world. The adventure begins.',
+      'A new life dawns as you are born.'
+    ], 'life');
+  }
   refreshOpenWindows();
   saveGame();
+}
+
+export function continueAsChild(index) {
+  const child = game.children?.[index];
+  if (!child) return;
+  const name = child.name ? child.name : `Child ${index + 1}`;
+  newLife(null, name, {
+    startYear: game.year,
+    age: child.age,
+    happiness: child.happiness,
+    skipBirthLog: true
+  });
+  addLog(`You continue life as ${name}.`, 'life');
 }
 
 window.addEventListener('beforeunload', saveGame);

--- a/tests/state.childContinuation.test.js
+++ b/tests/state.childContinuation.test.js
@@ -1,0 +1,43 @@
+import { jest } from '@jest/globals';
+
+const storage = {};
+global.window = { addEventListener: jest.fn() };
+global.localStorage = {
+  setItem: (k, v) => {
+    storage[k] = String(v);
+  },
+  getItem: k => (k in storage ? storage[k] : null),
+  removeItem: k => {
+    delete storage[k];
+  }
+};
+
+jest.unstable_mockModule('../windowManager.js', () => ({
+  refreshOpenWindows: jest.fn(),
+  openWindow: jest.fn(),
+  closeWindow: jest.fn(),
+  closeAllWindows: jest.fn()
+}));
+
+jest.unstable_mockModule('../endscreen.js', () => ({
+  showEndScreen: jest.fn(),
+  hideEndScreen: jest.fn()
+}));
+
+jest.unstable_mockModule('../realestate.js', () => ({
+  initBrokers: jest.fn(() => Promise.resolve())
+}));
+
+const { continueAsChild, game, lifeState } = await import('../state.js');
+
+describe('continueAsChild', () => {
+  test('starts new life as existing child', () => {
+    game.children = [{ name: 'Junior', age: 7, happiness: 80 }];
+    game.year = 1995;
+    continueAsChild(0);
+    expect(game.name).toBe('Junior');
+    expect(game.age).toBe(7);
+    expect(game.year).toBe(1995);
+    expect(lifeState.state).toBe('alive');
+  });
+});


### PR DESCRIPTION
## Summary
- Allow new lives to override starting parameters (age, happiness, etc.)
- Add ability to restart as one of your children after death
- Present child selection in New Life window and test the continuation logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba12ade308832abef96027505a7e52