### PR TITLE
Add disease system and doctor interactions

### DIFF
--- a/actions/ageUp.js
+++ b/actions/ageUp.js
@@ -26,6 +26,15 @@ function collectDividends() {
   return total;
 }
 
+function progressDiseases() {
+  if (!Array.isArray(game.diseases) || game.diseases.length === 0) return;
+  game.diseases = game.diseases.filter(d => d.severity > 0);
+  for (const dis of game.diseases) {
+    dis.severity = Math.min(dis.severity + 1, 10);
+    game.health = clamp(game.health - dis.severity);
+  }
+}
+
 function randomEvent() {
   if (game.age === 5) {
     addLog([
@@ -330,6 +339,7 @@ export function ageUp() {
         addLog(`Your ${pet.type} has passed away.`, 'pet');
       }
     }
+    progressDiseases();
     tickJail();
     tickRelationships();
   });

--- a/activities/doctor.js
+++ b/activities/doctor.js
@@ -6,6 +6,14 @@ const INSURANCE_PLANS = [
   { level: 2, cost: 250, discount: 0.4, name: 'Premium Insurance' }
 ];
 
+const POSSIBLE_DISEASES = [
+  { name: 'Diabetes', chronic: true },
+  { name: 'Hypertension', chronic: true },
+  { name: 'Asthma', chronic: true },
+  { name: 'Infection', chronic: false },
+  { name: 'Flu', chronic: false }
+];
+
 function doctorCost(base) {
   const plan = INSURANCE_PLANS.find(p => p.level === game.insuranceLevel);
   return plan ? Math.ceil(base * (1 - plan.discount)) : base;
@@ -86,6 +94,80 @@ export function renderDoctor(container) {
       !game.sick
     )
   );
+
+  const diagnoseCost = doctorCost(80);
+  wrap.appendChild(
+    mk(`Diagnose Disease ($${diagnoseCost})`, () => {
+      const cost = doctorCost(80);
+      if (game.money < cost) {
+        applyAndSave(() => {
+          addLog(`Doctor visit costs $${cost}. Not enough money.`, 'health');
+        });
+        return;
+      }
+      applyAndSave(() => {
+        game.money -= cost;
+        const available = POSSIBLE_DISEASES.filter(
+          d => !game.diseases?.some(g => g.name === d.name)
+        );
+        if (available.length === 0) {
+          addLog('No new diseases were found.', 'health');
+          return;
+        }
+        const diag = available[rand(0, available.length - 1)];
+        const severity = rand(1, 3);
+        game.diseases = game.diseases || [];
+        game.diseases.push({ name: diag.name, severity, chronic: diag.chronic });
+        addLog(`You were diagnosed with ${diag.name}.`, 'health');
+      });
+    })
+  );
+
+  for (const dis of game.diseases || []) {
+    if (dis.chronic) {
+      const manageCost = doctorCost(100);
+      wrap.appendChild(
+        mk(`Manage ${dis.name} (S${dis.severity}) ($${manageCost})`, () => {
+          const cost = doctorCost(100);
+          if (game.money < cost) {
+            applyAndSave(() => {
+              addLog(`Doctor visit costs $${cost}. Not enough money.`, 'health');
+            });
+            return;
+          }
+          applyAndSave(() => {
+            game.money -= cost;
+            dis.severity = Math.max(1, dis.severity - rand(1, 2));
+            addLog(`You managed your ${dis.name}. (-Severity)`, 'health');
+          });
+        })
+      );
+    } else {
+      const treatCost = doctorCost(120);
+      wrap.appendChild(
+        mk(`Treat ${dis.name} (S${dis.severity}) ($${treatCost})`, () => {
+          const cost = doctorCost(120);
+          if (game.money < cost) {
+            applyAndSave(() => {
+              addLog(`Doctor visit costs $${cost}. Not enough money.`, 'health');
+            });
+            return;
+          }
+          applyAndSave(() => {
+            game.money -= cost;
+            dis.severity = clamp(dis.severity - rand(3, 6));
+            if (dis.severity <= 0) {
+              game.diseases = game.diseases.filter(d => d !== dis);
+              game.health = clamp(game.health + rand(4, 8));
+              addLog(`You recovered from ${dis.name}. (+Health)`, 'health');
+            } else {
+              addLog(`Treatment reduced severity of ${dis.name}.`, 'health');
+            }
+          });
+        })
+      );
+    }
+  }
 
   const note = document.createElement('div');
   note.className = 'muted';

--- a/state.js
+++ b/state.js
@@ -109,6 +109,7 @@ export const game = {
   inJail: false,
   onParole: false,
   alive: true,
+  diseases: [],
   skills: {
     gambling: 0,
     racing: 0,
@@ -390,6 +391,7 @@ export function newLife(genderInput, nameInput, options = {}) {
     sick: false,
     inJail: false,
     alive: true,
+    diseases: [],
     skills: {
       gambling: 0,
       racing: 0,


### PR DESCRIPTION
## Summary
- track ongoing illnesses with new `diseases` array in game state
- expand doctor visit options to diagnose, treat or manage chronic conditions
- age progression now worsens existing diseases and reduces health

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba1a2442b8832a9cdbe4a2aab1718b