### PR TITLE
Handle relative aging and inheritance

### DIFF
--- a/actions/ageUp.js
+++ b/actions/ageUp.js
@@ -1,4 +1,12 @@
-import { game, addLog, saveGame, applyAndSave, unlockAchievement, die } from '../state.js';
+import {
+  game,
+  addLog,
+  saveGame,
+  applyAndSave,
+  unlockAchievement,
+  die,
+  distributeInheritance
+} from '../state.js';
 import { rand, clamp } from '../utils.js';
 import { tickJail } from '../jail.js';
 import { tickRelationships } from '../activities/love.js';
@@ -274,6 +282,30 @@ export function ageUp() {
             'Your child is now all grown up.'
           ], 'family');
           unlockAchievement('raise-child', 'Raised a child to adulthood.');
+        }
+      }
+    }
+    if (game.parents) {
+      for (const key of ['mother', 'father']) {
+        const parent = game.parents[key];
+        if (!parent) continue;
+        if (parent.health <= 0) {
+          addLog(parent.cause || `Your ${key} passed away.`, 'family');
+          distributeInheritance(key);
+          delete game.parents[key];
+        } else {
+          parent.age += 1;
+        }
+      }
+    }
+    if (game.siblings && game.siblings.length > 0) {
+      for (let i = game.siblings.length - 1; i >= 0; i--) {
+        const sib = game.siblings[i];
+        if (sib.health <= 0) {
+          addLog(sib.cause || `${sib.name || 'Your sibling'} passed away.`, 'family');
+          game.siblings.splice(i, 1);
+        } else {
+          sib.age += 1;
         }
       }
     }

--- a/state.js
+++ b/state.js
@@ -88,6 +88,7 @@ export const game = {
   jobListingsYear: null,
   relationships: [],
   children: [],
+  siblings: [],
   parents: {
     mother: randomParent(),
     father: randomParent()
@@ -173,6 +174,15 @@ export function addLog(text, category = 'general') {
   game.log.unshift({ when, text, category });
   if (game.log.length > 200) game.log.pop();
   refreshOpenWindows();
+}
+
+export function distributeInheritance(relative) {
+  const amount = rand(5000, 20000);
+  game.money += amount;
+  addLog(
+    `Your ${relative} left you $${amount.toLocaleString()} in inheritance. (+Money)`,
+    'family'
+  );
 }
 
 export function unlockAchievement(id) {
@@ -370,6 +380,7 @@ export function newLife(genderInput, nameInput, options = {}) {
     jobListingsYear: null,
     relationships: [],
     children: [],
+    siblings: options.siblings ?? [],
     parents: options.parents ?? {
       mother: randomParent(),
       father: randomParent()

--- a/tests/actions.ageUp.test.js
+++ b/tests/actions.ageUp.test.js
@@ -28,7 +28,8 @@ const game = {
   parents: {
     mother: { age: 50, health: 80 },
     father: { age: 52, health: 80 }
-  }
+  },
+  siblings: []
 };
 
 const addLog = jest.fn();
@@ -36,6 +37,14 @@ const die = jest.fn();
 const saveGame = jest.fn();
 const applyAndSave = jest.fn(fn => fn());
 const unlockAchievement = jest.fn();
+const distributeInheritance = jest.fn(relative => {
+  const amount = 10000;
+  game.money += amount;
+  addLog(
+    `Your ${relative} left you $${amount.toLocaleString()} in inheritance. (+Money)`,
+    'family'
+  );
+});
 
 jest.unstable_mockModule('../state.js', () => ({
   game,
@@ -43,7 +52,8 @@ jest.unstable_mockModule('../state.js', () => ({
   die,
   saveGame,
   applyAndSave,
-  unlockAchievement
+  unlockAchievement,
+  distributeInheritance
 }));
 
 const randValues = [1, 2, 11, 3, 10, 2, 2, 2, 2, 2];
@@ -55,7 +65,6 @@ jest.unstable_mockModule('../utils.js', () => ({
 
 jest.unstable_mockModule('../jail.js', () => ({ tickJail: jest.fn() }));
 jest.unstable_mockModule('../activities/love.js', () => ({ tickRelationships: jest.fn() }));
-jest.unstable_mockModule('../actions/elderCare.js', () => ({ tickParents: jest.fn() }));
 jest.unstable_mockModule('../realestate.js', () => ({ tickRealEstate: jest.fn() }));
 jest.unstable_mockModule('../activities/business.js', () => ({ tickBusinesses: jest.fn() }));
 jest.unstable_mockModule('../school.js', () => ({
@@ -110,7 +119,8 @@ describe('ageUp', () => {
       parents: {
         mother: { age: 50, health: 80 },
         father: { age: 52, health: 80 }
-      }
+      },
+      siblings: []
     });
     randCall = 0;
   });
@@ -158,6 +168,20 @@ describe('ageUp', () => {
     ageUp();
     expect(mockedGame.health).toBe(83);
     expect(mockedGame.sick).toBe(false);
+  });
+
+  test('ages relatives and handles deaths with inheritance', () => {
+    game.parents.mother.health = 0;
+    game.parents.mother.cause = 'Heart attack';
+    game.siblings = [{ name: 'Alex', age: 20, health: 0, cause: 'Accident' }];
+    addLog.mockClear();
+    ageUp();
+    expect(game.parents.mother).toBeUndefined();
+    expect(game.parents.father.age).toBe(53);
+    expect(game.siblings.length).toBe(0);
+    expect(addLog).toHaveBeenCalledWith('Heart attack', 'family');
+    expect(addLog).toHaveBeenCalledWith('Accident', 'family');
+    expect(distributeInheritance).toHaveBeenCalledWith('mother');
   });
 });
 

--- a/tests/actions.crime.test.js
+++ b/tests/actions.crime.test.js
@@ -22,7 +22,8 @@ jest.unstable_mockModule('../state.js', () => ({
   die,
   saveGame,
   applyAndSave,
-  unlockAchievement
+  unlockAchievement,
+  distributeInheritance: jest.fn()
 }));
 
 jest.unstable_mockModule('../utils.js', () => ({


### PR DESCRIPTION
## Summary
- Age parents and siblings each year and remove deceased relatives with logged causes of death
- Pay out parent inheritances when they die via new `distributeInheritance` helper
- Track siblings in game state and cover inheritance flows with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba1a22c630832a9921737cabed84a6