### PR TITLE
Add sibling interactions and activity

### DIFF
--- a/actions/family.js
+++ b/actions/family.js
@@ -61,3 +61,29 @@ export function spendTimeWithChild(index = 0) {
   });
 }
 
+export function spendTimeWithSibling(index = 0) {
+  if (!game.alive || !game.siblings || !game.siblings[index]) return;
+  applyAndSave(() => {
+    const sibling = game.siblings[index];
+    sibling.happiness = clamp(sibling.happiness + rand(5, 15));
+    addLog([
+      'You spent quality time with your sibling. (+Sibling Happiness)',
+      'Bonding with your sibling lifted their spirits. (+Sibling Happiness)',
+      'You enjoyed time with your sibling. (+Sibling Happiness)'
+    ], 'family');
+  });
+}
+
+export function siblingRivalry(index = 0) {
+  if (!game.alive || !game.siblings || !game.siblings[index]) return;
+  applyAndSave(() => {
+    const sibling = game.siblings[index];
+    sibling.happiness = clamp(sibling.happiness - rand(5, 15));
+    addLog([
+      'A rivalry with your sibling caused tension. (-Sibling Happiness)',
+      'You argued with your sibling. (-Sibling Happiness)',
+      'Sibling rivalry flared up. (-Sibling Happiness)'
+    ], 'family');
+  });
+}
+

--- a/actions/index.js
+++ b/actions/index.js
@@ -101,7 +101,13 @@ export { dropOut, enrollCollege, enrollUniversity, reEnrollHighSchool, getGed } 
 export { workExtra, retire } from './job.js';
 export { seeDoctor } from './health.js';
 export { crime } from './crime.js';
-export { hostFamilyGathering, haveChild, spendTimeWithChild } from './family.js';
+export {
+  hostFamilyGathering,
+  haveChild,
+  spendTimeWithChild,
+  spendTimeWithSibling,
+  siblingRivalry
+} from './family.js';
 export { buyCar, scheduleMaintenance } from './cars.js';
 export { renovateProperty } from './renovateProperty.js';
 export { ageUp } from './ageUp.js';

--- a/activities/siblings.js
+++ b/activities/siblings.js
@@ -1,0 +1,46 @@
+import { game } from '../state.js';
+import { spendTimeWithSibling, siblingRivalry } from '../actions/family.js';
+
+export function renderSiblings(container) {
+  game.siblings = game.siblings || [];
+  const wrap = document.createElement('div');
+
+  if (!game.siblings.length) {
+    const note = document.createElement('div');
+    note.className = 'muted';
+    note.textContent = 'You have no siblings.';
+    wrap.appendChild(note);
+    container.appendChild(wrap);
+    return;
+  }
+
+  for (let i = 0; i < game.siblings.length; i++) {
+    const sibling = game.siblings[i];
+    const row = document.createElement('div');
+    row.className = 'sibling';
+
+    const info = document.createElement('div');
+    const name = sibling.name ? sibling.name : `Sibling ${i + 1}`;
+    info.innerHTML = `<strong>${name}</strong> Age ${sibling.age} • Happiness ${sibling.happiness}`;
+    row.appendChild(info);
+
+    const actions = document.createElement('div');
+    const spend = document.createElement('button');
+    spend.className = 'btn';
+    spend.textContent = 'Spend Time';
+    spend.addEventListener('click', () => spendTimeWithSibling(i));
+    actions.appendChild(spend);
+
+    const rivalry = document.createElement('button');
+    rivalry.className = 'btn';
+    rivalry.textContent = 'Rivalry';
+    rivalry.addEventListener('click', () => siblingRivalry(i));
+    actions.appendChild(rivalry);
+
+    row.appendChild(actions);
+    wrap.appendChild(row);
+  }
+
+  container.appendChild(wrap);
+}
+

--- a/renderers/activities.js
+++ b/renderers/activities.js
@@ -39,7 +39,8 @@ const ACTIVITIES_CATEGORIES = {
     'Pets',
     'Zoo',
     'Zoo Trip',
-    'Elder Care'
+    'Elder Care',
+    'Siblings'
   ],
   'Gambling & Racing': [
     'Casino',
@@ -97,6 +98,7 @@ const ACTIVITY_ICONS = {
   Zoo: '🦁',
   'Zoo Trip': '🚌',
   'Elder Care': '👴',
+  Siblings: '👫',
   Casino: '🎰',
   Gamble: '🎲',
   Lottery: '🎟️',
@@ -141,6 +143,7 @@ const ACTIVITY_RENDERERS = {
   Daycare: () => openActivity('daycare', 'Daycare', '../activities/daycare.js', 'renderDaycare'),
   Fertility: () => openActivity('fertility', 'Fertility', '../activities/fertility.js', 'renderFertility'),
   'Elder Care': () => openActivity('elderCare', 'Elder Care', '../activities/elderCare.js', 'renderElderCare'),
+  Siblings: () => openActivity('siblings', 'Siblings', '../activities/siblings.js', 'renderSiblings'),
   Lottery: () => openActivity('lottery', 'Lottery', '../activities/lottery.js', 'renderLottery'),
   'Movie Theater': () => openActivity('movieTheater', 'Movie Theater', '../activities/movieTheater.js', 'renderMovieTheater'),
   'Social Media': () => openActivity('socialmedia', 'Social Media', '../activities/socialMedia.js', 'renderSocialMedia'),
@@ -200,8 +203,8 @@ export function renderActivities(container) {
 
     for (const item of items) {
       if (
-        item === 'Daycare' &&
-        (!game.job || !game.children || game.children.length === 0)
+        (item === 'Daycare' && (!game.job || !game.children || game.children.length === 0)) ||
+        (item === 'Siblings' && (!game.siblings || game.siblings.length === 0))
       ) {
         continue;
       }

--- a/state.js
+++ b/state.js
@@ -19,6 +19,15 @@ function randomParent() {
   return { age: rand(20, 60), health: rand(60, 100) };
 }
 
+function randomSiblings() {
+  const count = rand(0, 3);
+  const siblings = [];
+  for (let i = 0; i < count; i++) {
+    siblings.push({ age: rand(0, 18), happiness: rand(40, 80) });
+  }
+  return siblings;
+}
+
 export const ACHIEVEMENTS = {
   'first-job': 'Got your first job.',
   'first-property': 'Bought your first property.',
@@ -88,6 +97,7 @@ export const game = {
   jobListingsYear: null,
   relationships: [],
   children: [],
+  siblings: [],
   parents: {
     mother: randomParent(),
     father: randomParent()
@@ -370,6 +380,7 @@ export function newLife(genderInput, nameInput, options = {}) {
     jobListingsYear: null,
     relationships: [],
     children: [],
+    siblings: options.siblings ?? randomSiblings(),
     parents: options.parents ?? {
       mother: randomParent(),
       father: randomParent()


### PR DESCRIPTION
## Summary
- Track randomly generated siblings in game state
- Add sibling interactions: spend time and rivalry
- Introduce Siblings activity and navigation entry

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba1a1ddb3c832a8fcc0c1d69928e3e