### PR TITLE
Add spouse interaction actions

### DIFF
--- a/actions/family.js
+++ b/actions/family.js
@@ -61,3 +61,33 @@ export function spendTimeWithChild(index = 0) {
   });
 }
 
+export function spendTimeWithSpouse(index = 0) {
+  if (!game.alive || !game.relationships || !game.relationships[index]) return;
+  applyAndSave(() => {
+    const rel = game.relationships[index];
+    rel.happiness = clamp(rel.happiness + rand(5, 15));
+    addLog([
+      `You spent quality time with ${rel.name}. (+Relationship Happiness)`,
+      `A nice day with ${rel.name} improved your bond. (+Relationship Happiness)`,
+      `You hung out with ${rel.name}. (+Relationship Happiness)`
+    ], 'relationship');
+  });
+}
+
+export function argueWithSpouse(index = 0) {
+  if (!game.alive || !game.relationships || !game.relationships[index]) return;
+  applyAndSave(() => {
+    const rel = game.relationships[index];
+    rel.happiness = clamp(rel.happiness - rand(5, 15));
+    addLog([
+      `You argued with ${rel.name}. (-Relationship Happiness)`,
+      `A disagreement with ${rel.name} hurt your bond. (-Relationship Happiness)`,
+      `You had a fight with ${rel.name}. (-Relationship Happiness)`
+    ], 'relationship');
+    if (rel.happiness <= 0) {
+      addLog(`${rel.name} left you.`, 'relationship');
+      game.relationships.splice(index, 1);
+    }
+  });
+}
+

--- a/actions/index.js
+++ b/actions/index.js
@@ -101,7 +101,13 @@ export { dropOut, enrollCollege, enrollUniversity, reEnrollHighSchool, getGed } 
 export { workExtra, retire } from './job.js';
 export { seeDoctor } from './health.js';
 export { crime } from './crime.js';
-export { hostFamilyGathering, haveChild, spendTimeWithChild } from './family.js';
+export {
+  hostFamilyGathering,
+  haveChild,
+  spendTimeWithChild,
+  spendTimeWithSpouse,
+  argueWithSpouse
+} from './family.js';
 export { buyCar, scheduleMaintenance } from './cars.js';
 export { renovateProperty } from './renovateProperty.js';
 export { ageUp } from './ageUp.js';

--- a/activities/love.js
+++ b/activities/love.js
@@ -1,6 +1,7 @@
 import { game, addLog, applyAndSave } from '../state.js';
 import { rand, clamp } from '../utils.js';
 import { getFaker } from '../utils/faker.js';
+import { spendTimeWithSpouse, argueWithSpouse } from '../actions/family.js';
 
 const faker = await getFaker();
 
@@ -23,6 +24,20 @@ export function renderLove(container) {
       const span = document.createElement('span');
       span.textContent = `${rel.name} (${rel.happiness}%)`;
       row.appendChild(span);
+
+      const spend = document.createElement('button');
+      spend.className = 'btn';
+      spend.textContent = 'Spend Time';
+      spend.style.marginLeft = '8px';
+      spend.addEventListener('click', () => spendTimeWithSpouse(i));
+      row.appendChild(spend);
+
+      const argue = document.createElement('button');
+      argue.className = 'btn';
+      argue.textContent = 'Argue';
+      argue.style.marginLeft = '8px';
+      argue.addEventListener('click', () => argueWithSpouse(i));
+      row.appendChild(argue);
 
       const btn = document.createElement('button');
       btn.className = 'btn';

--- a/tests/actions.family.test.js
+++ b/tests/actions.family.test.js
@@ -1,0 +1,48 @@
+import { jest } from '@jest/globals';
+
+const rand = jest.fn((min) => min);
+const game = { relationships: [] };
+const addLog = jest.fn();
+const applyAndSave = (fn) => fn();
+
+await jest.unstable_mockModule('../utils.js', () => ({
+  rand,
+  clamp: (v, a = 0, b = 100) => Math.max(a, Math.min(b, v))
+}));
+
+await jest.unstable_mockModule('../state.js', () => ({
+  game,
+  addLog,
+  applyAndSave,
+  saveGame: jest.fn(),
+  unlockAchievement: jest.fn()
+}));
+
+const {
+  spendTimeWithSpouse,
+  argueWithSpouse
+} = await import('../actions/family.js');
+
+describe('spouse interactions', () => {
+  beforeEach(() => {
+    rand.mockImplementation((min) => min);
+    addLog.mockClear();
+    game.alive = true;
+  });
+
+  test('spending time increases happiness and logs', () => {
+    game.relationships = [{ name: 'Pat', happiness: 50 }];
+    spendTimeWithSpouse(0);
+    expect(game.relationships[0].happiness).toBe(55);
+    expect(addLog).toHaveBeenCalledWith(expect.any(Array), 'relationship');
+  });
+
+  test('arguing decreases happiness and removes at zero', () => {
+    game.relationships = [{ name: 'Sam', happiness: 5 }];
+    argueWithSpouse(0);
+    expect(game.relationships).toHaveLength(0);
+    expect(addLog).toHaveBeenNthCalledWith(1, expect.any(Array), 'relationship');
+    expect(addLog).toHaveBeenNthCalledWith(2, 'Sam left you.', 'relationship');
+  });
+});
+

--- a/tests/activities.love.test.js
+++ b/tests/activities.love.test.js
@@ -9,7 +9,9 @@ const applyAndSave = fn => fn();
 await jest.unstable_mockModule('../state.js', () => ({
   game,
   addLog,
-  applyAndSave
+  applyAndSave,
+  saveGame: jest.fn(),
+  unlockAchievement: jest.fn()
 }));
 
 const { tickRelationships } = await import('../activities/love.js');


### PR DESCRIPTION
## Summary
- add "Spend Time" and "Argue" relationship actions
- support new spouse interaction helpers to adjust happiness and log events
- cover spouse interactions with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba1a1bc204832a9857d29091b153b4