### PR TITLE
Add marriage system with spouse management

### DIFF
--- a/actions/ageUp.js
+++ b/actions/ageUp.js
@@ -1,7 +1,7 @@
 import { game, addLog, saveGame, applyAndSave, unlockAchievement, die } from '../state.js';
 import { rand, clamp } from '../utils.js';
 import { tickJail } from '../jail.js';
-import { tickRelationships } from '../activities/love.js';
+import { tickRelationships, tickSpouse } from '../activities/love.js';
 import { tickRealEstate } from '../realestate.js';
 import { tickBusinesses } from '../activities/business.js';
 import * as school from '../school.js';
@@ -332,6 +332,7 @@ export function ageUp() {
     }
     tickJail();
     tickRelationships();
+    tickSpouse();
   });
 }
 

--- a/activities/love.js
+++ b/activities/love.js
@@ -8,36 +8,78 @@ export function renderLove(container) {
   const wrap = document.createElement('div');
 
   const list = document.createElement('div');
-  if (!game.relationships.length) {
+  if (game.spouse) {
+    const row = document.createElement('div');
+    row.style.display = 'flex';
+    row.style.alignItems = 'center';
+    row.style.margin = '4px 0';
+
+    const span = document.createElement('span');
+    span.textContent = `${game.spouse.name} (Spouse, ${game.spouse.happiness}%)`;
+    row.appendChild(span);
+
+    const btn = document.createElement('button');
+    btn.className = 'btn';
+    btn.textContent = 'Divorce';
+    btn.style.marginLeft = 'auto';
+    btn.addEventListener('click', () => {
+      applyAndSave(() => {
+        addLog(`You divorced ${game.spouse.name}.`, 'relationship');
+        game.spouse = null;
+        game.maritalStatus = 'single';
+      });
+    });
+    row.appendChild(btn);
+
+    list.appendChild(row);
+  }
+  if (!game.spouse && !game.relationships.length) {
     const none = document.createElement('div');
     none.className = 'muted';
     none.textContent = 'You are currently single.';
     list.appendChild(none);
-  } else {
-    for (const [i, rel] of game.relationships.entries()) {
-      const row = document.createElement('div');
-      row.style.display = 'flex';
-      row.style.alignItems = 'center';
-      row.style.margin = '4px 0';
+  }
+  for (const [i, rel] of game.relationships.entries()) {
+    const row = document.createElement('div');
+    row.style.display = 'flex';
+    row.style.alignItems = 'center';
+    row.style.margin = '4px 0';
 
-      const span = document.createElement('span');
-      span.textContent = `${rel.name} (${rel.happiness}%)`;
-      row.appendChild(span);
+    const span = document.createElement('span');
+    span.textContent = `${rel.name} (${rel.happiness}%)`;
+    row.appendChild(span);
 
-      const btn = document.createElement('button');
-      btn.className = 'btn';
-      btn.textContent = 'Break up';
-      btn.style.marginLeft = 'auto';
-      btn.addEventListener('click', () => {
-        applyAndSave(() => {
+    const proposeBtn = document.createElement('button');
+    proposeBtn.className = 'btn';
+    proposeBtn.textContent = 'Propose';
+    proposeBtn.style.marginLeft = 'auto';
+    proposeBtn.addEventListener('click', () => {
+      applyAndSave(() => {
+        if (rand(1, 100) <= rel.happiness) {
+          game.spouse = rel;
+          game.maritalStatus = 'married';
           game.relationships.splice(i, 1);
-          addLog(`You broke up with ${rel.name}.`, 'relationship');
-        });
+          addLog(`You married ${rel.name}.`, 'relationship');
+        } else {
+          addLog(`${rel.name} rejected your proposal.`, 'relationship');
+        }
       });
-      row.appendChild(btn);
+    });
+    row.appendChild(proposeBtn);
 
-      list.appendChild(row);
-    }
+    const btn = document.createElement('button');
+    btn.className = 'btn';
+    btn.textContent = 'Break up';
+    btn.style.marginLeft = '4px';
+    btn.addEventListener('click', () => {
+      applyAndSave(() => {
+        game.relationships.splice(i, 1);
+        addLog(`You broke up with ${rel.name}.`, 'relationship');
+      });
+    });
+    row.appendChild(btn);
+
+    list.appendChild(row);
   }
   wrap.appendChild(list);
 
@@ -66,6 +108,18 @@ export function tickRelationships() {
         addLog(`${r.name} left you.`, 'relationship');
         game.relationships.splice(i, 1);
       }
+    }
+  });
+}
+
+export function tickSpouse() {
+  applyAndSave(() => {
+    if (!game.spouse) return;
+    game.spouse.happiness = clamp(game.spouse.happiness + rand(-10, 5));
+    if (game.spouse.happiness <= 0) {
+      addLog(`${game.spouse.name} divorced you.`, 'relationship');
+      game.spouse = null;
+      game.maritalStatus = 'single';
     }
   });
 }

--- a/state.js
+++ b/state.js
@@ -87,6 +87,8 @@ export const game = {
   jobListings: [],
   jobListingsYear: null,
   relationships: [],
+  maritalStatus: 'single',
+  spouse: null,
   children: [],
   parents: {
     mother: randomParent(),
@@ -276,6 +278,12 @@ export function loadGame(slot = currentSlot) {
     if (game.lastPost === undefined) {
       game.lastPost = 0;
     }
+    if (!('maritalStatus' in game)) {
+      game.maritalStatus = 'single';
+    }
+    if (!('spouse' in game)) {
+      game.spouse = null;
+    }
   } catch {
     localStorage.removeItem(`gameState_${slot}`);
     deleteSlot(slot);
@@ -369,6 +377,8 @@ export function newLife(genderInput, nameInput, options = {}) {
     jobListings: [],
     jobListingsYear: null,
     relationships: [],
+    maritalStatus: 'single',
+    spouse: null,
     children: [],
     parents: options.parents ?? {
       mother: randomParent(),

--- a/tests/actions.ageUp.test.js
+++ b/tests/actions.ageUp.test.js
@@ -54,7 +54,7 @@ jest.unstable_mockModule('../utils.js', () => ({
 }));
 
 jest.unstable_mockModule('../jail.js', () => ({ tickJail: jest.fn() }));
-jest.unstable_mockModule('../activities/love.js', () => ({ tickRelationships: jest.fn() }));
+jest.unstable_mockModule('../activities/love.js', () => ({ tickRelationships: jest.fn(), tickSpouse: jest.fn() }));
 jest.unstable_mockModule('../actions/elderCare.js', () => ({ tickParents: jest.fn() }));
 jest.unstable_mockModule('../realestate.js', () => ({ tickRealEstate: jest.fn() }));
 jest.unstable_mockModule('../activities/business.js', () => ({ tickBusinesses: jest.fn() }));

--- a/tests/actions.health.test.js
+++ b/tests/actions.health.test.js
@@ -30,7 +30,8 @@ await jest.unstable_mockModule('../endscreen.js', () => ({
 await jest.unstable_mockModule('../jail.js', () => ({ tickJail: jest.fn() }));
 
 await jest.unstable_mockModule('../activities/love.js', () => ({
-  tickRelationships: jest.fn()
+  tickRelationships: jest.fn(),
+  tickSpouse: jest.fn()
 }));
 
 await jest.unstable_mockModule('../realestate.js', () => ({

--- a/tests/activities.love.test.js
+++ b/tests/activities.love.test.js
@@ -1,6 +1,6 @@
 import { jest } from '@jest/globals';
 
-const game = { relationships: [], log: [] };
+const game = { relationships: [], log: [], spouse: null, maritalStatus: 'single' };
 const addLog = jest.fn((text, category = 'general') => {
   game.log.unshift({ text, category });
 });
@@ -12,7 +12,7 @@ await jest.unstable_mockModule('../state.js', () => ({
   applyAndSave
 }));
 
-const { tickRelationships } = await import('../activities/love.js');
+const { tickRelationships, tickSpouse } = await import('../activities/love.js');
 
 describe('tickRelationships', () => {
   const originalRandom = Math.random;
@@ -23,6 +23,7 @@ describe('tickRelationships', () => {
       { name: 'Alex Smith', happiness: 5 },
       { name: 'Jamie Doe', happiness: 2 }
     ];
+    game.spouse = null;
     game.log = [];
     addLog.mockClear();
   });
@@ -39,6 +40,27 @@ describe('tickRelationships', () => {
       { text: 'Alex Smith left you.', category: 'relationship' },
       { text: 'Jamie Doe left you.', category: 'relationship' }
     ]);
+  });
+});
+
+describe('tickSpouse', () => {
+  const originalRandom = Math.random;
+
+  beforeEach(() => {
+    Math.random = () => 0;
+    game.spouse = { name: 'Taylor Lee', happiness: 1 };
+    game.log = [];
+    addLog.mockClear();
+  });
+
+  afterEach(() => {
+    Math.random = originalRandom;
+  });
+
+  test('removes unhappy spouse and logs divorce', () => {
+    tickSpouse();
+    expect(game.spouse).toBeNull();
+    expect(addLog).toHaveBeenCalledWith('Taylor Lee divorced you.', 'relationship');
   });
 });
 


### PR DESCRIPTION
## Summary
- Track marriage via new `maritalStatus` and `spouse` fields in game state
- Allow proposing to partners and divorcing spouses through Love activity UI
- Age progression now adjusts spouse happiness and divorces unhappy spouses

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba1a14c28c832aaf5af98d80670f81