### PR TITLE
Add sports careers and activities with aging effects

### DIFF
--- a/actions/ageUp.js
+++ b/actions/ageUp.js
@@ -1,4 +1,5 @@
-import { game, addLog, saveGame, applyAndSave, unlockAchievement, die } from '../state.js';
+import * as state from '../state.js';
+const { game, addLog, saveGame, applyAndSave, unlockAchievement, die } = state;
 import { rand, clamp } from '../utils.js';
 import { tickJail } from '../jail.js';
 import { tickRelationships } from '../activities/love.js';
@@ -205,6 +206,7 @@ export function ageUp() {
   }
   applyAndSave(() => {
     game.age += 1;
+    state.updateAthleticPerformance?.();
     game.year += 1;
     advanceSchool();
     let healthLoss = rand(1, 4);

--- a/activities/sports.js
+++ b/activities/sports.js
@@ -1,0 +1,62 @@
+import { game, addLog, applyAndSave } from '../state.js';
+import { rand, clamp } from '../utils.js';
+
+export function renderSports(container) {
+  const wrap = document.createElement('div');
+
+  const trainBtn = document.createElement('button');
+  trainBtn.className = 'btn';
+  trainBtn.textContent = 'Train';
+  trainBtn.addEventListener('click', () => {
+    applyAndSave(() => {
+      const gain = rand(2, 5);
+      game.skills.fitness += gain;
+      game.health = clamp(game.health + gain);
+      addLog(`You trained hard. +${gain} Fitness and Health.`, 'health');
+    });
+  });
+  wrap.appendChild(trainBtn);
+
+  const tourBtn = document.createElement('button');
+  tourBtn.className = 'btn';
+  tourBtn.textContent = 'Enter Tournament';
+  tourBtn.addEventListener('click', () => {
+    applyAndSave(() => {
+      game.athleticRecord.tournaments += 1;
+      const chance = Math.min(50 + game.skills.fitness, 95);
+      if (rand(1, 100) <= chance) {
+        const prize = rand(5000, 20000);
+        game.money += prize;
+        game.athleticRecord.wins += 1;
+        game.happiness = clamp(game.happiness + rand(5, 10));
+        addLog(`You won the tournament and earned $${prize.toLocaleString()}.`, 'leisure');
+      } else {
+        const loss = rand(2, 6);
+        game.health = clamp(game.health - loss);
+        addLog(`You lost the tournament. -${loss} Health.`, 'leisure');
+      }
+    });
+  });
+  wrap.appendChild(tourBtn);
+
+  const endorseBtn = document.createElement('button');
+  endorseBtn.className = 'btn';
+  endorseBtn.textContent = 'Seek Endorsement';
+  endorseBtn.addEventListener('click', () => {
+    applyAndSave(() => {
+      if (game.athleticRecord.wins === 0) {
+        addLog('No brands are interested yet. Win a tournament first.', 'job');
+        return;
+      }
+      const pay = rand(2000, 10000) + game.athleticRecord.wins * 500;
+      game.money += pay;
+      game.followers += rand(100, 500);
+      game.athleticRecord.endorsements += 1;
+      addLog(`You signed an endorsement deal for $${pay.toLocaleString()}.`, 'job');
+    });
+  });
+  wrap.appendChild(endorseBtn);
+
+  container.appendChild(wrap);
+}
+

--- a/jobs.js
+++ b/jobs.js
@@ -304,6 +304,17 @@ const jobFields = {
       ['Chief Transportation Officer', 110000, 'university']
     ]
   },
+  sports: {
+    entry: [
+      ['Minor League Player', 40000, 'none', null, null, 70]
+    ],
+    mid: [
+      ['Professional Athlete', 120000, 'none', null, null, 85]
+    ],
+    senior: [
+      ['Sports Legend', 250000, 'none', null, null, 90]
+    ]
+  },
   influencer: {
     entry: [
       ['Micro Influencer', 30000, 'none', null, 1000]
@@ -357,7 +368,7 @@ for (const [field, levels] of Object.entries(jobFields)) {
   if (Array.isArray(levels)) continue;
   const fieldYear = fieldDiscoveryYear[field] || 0;
   for (const [level, jobs] of Object.entries(levels)) {
-    for (const [title, base, edu, major, followers] of jobs) {
+    for (const [title, base, edu, major, followers, fitness] of jobs) {
       const availableFrom = jobDiscoveryYear[title] || fieldYear;
       allJobs.push({
         field,
@@ -367,6 +378,7 @@ for (const [field, levels] of Object.entries(jobFields)) {
         reqEdu: edu,
         reqMajor: major,
         reqFollowers: followers,
+        reqFitness: fitness,
         tuitionAssistance: ['education', 'healthcare', 'law'].includes(field),
         availableFrom
       });
@@ -403,7 +415,11 @@ export function generateJobs() {
   const count = phase === 'boom' ? 8 : phase === 'recession' ? 4 : 6;
   const mod = phase === 'boom' ? 1.2 : phase === 'recession' ? 0.8 : 1;
   const jobPool = allJobs.filter(
-    j => j.availableFrom <= game.year && (!j.reqMajor || j.reqMajor === game.major) && (!j.reqFollowers || j.reqFollowers <= game.followers)
+    j =>
+      j.availableFrom <= game.year &&
+      (!j.reqMajor || j.reqMajor === game.major) &&
+      (!j.reqFollowers || j.reqFollowers <= game.followers) &&
+      (!j.reqFitness || j.reqFitness <= game.skills.fitness)
   );
   for (let i = 0; i < count && jobPool.length; i++) {
     const job = jobPool[rand(0, jobPool.length - 1)];

--- a/renderers/activities.js
+++ b/renderers/activities.js
@@ -60,6 +60,7 @@ const ACTIVITIES_CATEGORIES = {
   ],
   'Health & Self-Improvement': [
     'Gym',
+    'Sports',
     'Doctor',
     'Plastic Surgery',
     'Rehab',
@@ -111,6 +112,7 @@ const ACTIVITY_ICONS = {
   Licenses: '📜',
   'Will & Testament': '📝',
   Gym: '🏋️',
+  Sports: '🏅',
   Doctor: '🩺',
   'Plastic Surgery': '💉',
   Rehab: '🚭',
@@ -127,6 +129,7 @@ const ACTIVITY_ICONS = {
 const ACTIVITY_RENDERERS = {
   Love: () => openActivity('love', 'Love', '../activities/love.js', 'renderLove'),
   Gym: () => openActivity('gym', 'Gym', '../activities/gym.js', 'renderGym'),
+  Sports: () => openActivity('sports', 'Sports', '../activities/sports.js', 'renderSports'),
   Doctor: () => openActivity('doctor', 'Doctor', '../activities/doctor.js', 'renderDoctor'),
   'Health Insurance': () => openActivity(
     'healthInsurance',

--- a/renderers/jobs.js
+++ b/renderers/jobs.js
@@ -75,7 +75,8 @@ export function renderJobs(container) {
     e.className = 'job';
     const okEdu = educationRank(game.education.highest) >= educationRank(j.reqEdu);
     const okMajor = !j.reqMajor || game.major === j.reqMajor;
-    const ok = okEdu && okMajor;
+    const okFitness = !j.reqFitness || game.skills.fitness >= j.reqFitness;
+    const ok = okEdu && okMajor && okFitness;
     const left = document.createElement('div');
     const strong = document.createElement('strong');
     strong.textContent = j.title;
@@ -85,6 +86,9 @@ export function renderJobs(container) {
     req.textContent = `Req Edu: ${eduName(j.reqEdu)}`;
     if (j.reqMajor) {
       req.textContent += ` | Req Major: ${j.reqMajor}`;
+    }
+    if (j.reqFitness) {
+      req.textContent += ` | Req Fitness: ${j.reqFitness}`;
     }
     left.appendChild(req);
     if (j.tuitionAssistance) {
@@ -105,9 +109,7 @@ export function renderJobs(container) {
     e.appendChild(left);
     e.appendChild(right);
     if (!ok) e.style.opacity = 0.6;
-    e.title = ok
-      ? 'Take job'
-      : 'You do not meet the education or major requirements';
+    e.title = ok ? 'Take job' : 'You do not meet the requirements';
     e.addEventListener('click', () => {
       if (!ok) {
         addLog(

--- a/state.js
+++ b/state.js
@@ -1,5 +1,5 @@
 import { refreshOpenWindows, openWindow, closeAllWindows } from './windowManager.js';
-import { rand } from './utils.js';
+import { rand, clamp } from './utils.js';
 import { StateMachine } from './utils/stateMachine.js';
 import { showEndScreen, hideEndScreen } from './endscreen.js';
 import { initBrokers } from './realestate.js';
@@ -113,6 +113,11 @@ export const game = {
     gambling: 0,
     racing: 0,
     fitness: 0
+  },
+  athleticRecord: {
+    tournaments: 0,
+    wins: 0,
+    endorsements: 0
   },
   log: []
 };
@@ -240,6 +245,13 @@ export function applyAndSave(updater) {
   saveGame();
 }
 
+export function updateAthleticPerformance() {
+  if (game.age > 30) {
+    const decline = Math.floor((game.age - 30) / 5) + 1;
+    game.skills.fitness = clamp(game.skills.fitness - decline);
+  }
+}
+
 export function loadGame(slot = currentSlot) {
   if (!storageAvailable()) {
     console.warn('Local storage is unavailable; cannot load game.');
@@ -254,6 +266,9 @@ export function loadGame(slot = currentSlot) {
       game.skills = { gambling: 0, racing: 0, fitness: 0 };
     } else if (game.skills.fitness === undefined) {
       game.skills.fitness = 0;
+    }
+    if (!game.athleticRecord) {
+      game.athleticRecord = { tournaments: 0, wins: 0, endorsements: 0 };
     }
     if (!game.businesses) {
       game.businesses = [];
@@ -394,6 +409,11 @@ export function newLife(genderInput, nameInput, options = {}) {
       gambling: 0,
       racing: 0,
       fitness: 0
+    },
+    athleticRecord: {
+      tournaments: 0,
+      wins: 0,
+      endorsements: 0
     },
     log: []
   });


### PR DESCRIPTION
## Summary
- add sports field jobs that require high fitness
- introduce sports activity for training, tournaments, and endorsements
- track athletic records and reduce fitness with age

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba1a329588832a908b3bf3448d18f3