### PR TITLE
Add employee management and bankruptcy mechanics

### DIFF
--- a/actions/ageUp.js
+++ b/actions/ageUp.js
@@ -261,6 +261,13 @@ export function ageUp() {
     }
     game.charityYear = 0;
     tickBusinesses();
+    for (let i = game.businesses.length - 1; i >= 0; i--) {
+      const biz = game.businesses[i];
+      if (biz.profit < 0) {
+        addLog(`Your business ${biz.name} went bankrupt.`, 'business');
+        game.businesses.splice(i, 1);
+      }
+    }
     if (game.children && game.children.length > 0) {
       for (const child of game.children) {
         child.age += 1;

--- a/activities/business.js
+++ b/activities/business.js
@@ -22,7 +22,8 @@ export function renderBusiness(container) {
         startupCost: cost,
         revenue: rand(8000, 30000),
         expenses: rand(4000, 15000),
-        employees: rand(1, 10),
+        employees: 0,
+        payroll: 0,
         profit: 0
       };
       game.businesses.push(biz);
@@ -30,17 +31,58 @@ export function renderBusiness(container) {
       if (game.businesses.length === 1) {
         unlockAchievement('first-business', 'Started your first business.');
       }
+      updateList();
     });
   });
 
   wrap.appendChild(startBtn);
+
+  const list = document.createElement('div');
+  wrap.appendChild(list);
+
+  function updateList() {
+    list.innerHTML = '';
+    game.businesses.forEach(biz => {
+      const row = document.createElement('div');
+      row.textContent = `${biz.name}: ${biz.employees} employees, Payroll $${
+        (biz.payroll || 0).toLocaleString()
+      }, Profit $${biz.profit.toLocaleString()}`;
+      const hire = document.createElement('button');
+      hire.className = 'btn';
+      hire.textContent = 'Hire';
+      hire.addEventListener('click', () => {
+        applyAndSave(() => {
+          biz.employees += 1;
+          addLog(`Hired an employee for ${biz.name}.`, 'business');
+          updateList();
+        });
+      });
+      const fire = document.createElement('button');
+      fire.className = 'btn';
+      fire.textContent = 'Fire';
+      fire.addEventListener('click', () => {
+        if (biz.employees <= 0) return;
+        applyAndSave(() => {
+          biz.employees -= 1;
+          addLog(`Fired an employee from ${biz.name}.`, 'business');
+          updateList();
+        });
+      });
+      row.appendChild(hire);
+      row.appendChild(fire);
+      list.appendChild(row);
+    });
+  }
+
+  updateList();
   container.appendChild(wrap);
 }
 
 export function tickBusinesses() {
   for (const biz of game.businesses) {
-    const annualCost = biz.expenses * biz.employees;
-    const profit = biz.revenue - annualCost;
+    const payroll = biz.expenses * biz.employees;
+    biz.payroll = payroll;
+    const profit = biz.revenue - payroll;
     game.money += profit;
     biz.profit += profit;
     addLog(

--- a/state.js
+++ b/state.js
@@ -257,6 +257,11 @@ export function loadGame(slot = currentSlot) {
     }
     if (!game.businesses) {
       game.businesses = [];
+    } else {
+      for (const biz of game.businesses) {
+        if (biz.employees === undefined) biz.employees = 0;
+        if (biz.profit === undefined) biz.profit = 0;
+      }
     }
     if (!('insurancePlan' in game)) {
       game.insurancePlan = null;


### PR DESCRIPTION
## Summary
- Allow hiring and firing employees in business activity with payroll tracking and profit updates
- Ensure loaded businesses include employee and profit fields
- Remove bankrupt businesses when profits fall below zero each year

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba1a3166b4832aae7e5a2e3229fc36