### PR TITLE
Add fame stat with celebrity jobs and social boosts

### DIFF
--- a/activities/socialMedia.js
+++ b/activities/socialMedia.js
@@ -1,4 +1,4 @@
-import { game, addLog, applyAndSave } from '../state.js';
+import { game, addLog, applyAndSave, updateFame } from '../state.js';
 import { clamp, rand } from '../utils.js';
 import { generateJobs } from '../jobs.js';
 
@@ -44,6 +44,11 @@ export function renderSocialMedia(container) {
       }
       addLog(message, 'social');
 
+      if (gained >= 15) {
+        game.fameBonus += 2;
+        addLog('Your post went viral! Fame +2.', 'social');
+      }
+
       if (rand(1, 100) <= 10) {
         const lost = Math.min(game.followers, rand(5, 15));
         const repLoss = rand(5, 15);
@@ -53,6 +58,8 @@ export function renderSocialMedia(container) {
           `A controversial post cost you ${lost} followers and ${repLoss} reputation.`,
           'social'
         );
+        game.fameBonus += 5;
+        addLog('The scandal made you more famous. Fame +5.', 'social');
       } else {
         let earnings = 0;
         if (game.followers >= 10000 && rand(1, 100) <= 20) {
@@ -69,6 +76,7 @@ export function renderSocialMedia(container) {
         }
       }
 
+      updateFame();
       game.lastPost = now;
       count.textContent = `Followers: ${game.followers}`;
       refreshJobs();
@@ -91,7 +99,12 @@ export function renderSocialMedia(container) {
       const gained = rand(50, 100);
       game.followers += gained;
       game.happiness = clamp(game.happiness + 5);
+      if (gained >= 80) {
+        game.fameBonus += 3;
+        addLog('Your promotion went viral! Fame +3.', 'social');
+      }
       addLog(`You promoted your account and gained ${gained} followers.`, 'social');
+      updateFame();
       count.textContent = `Followers: ${game.followers}`;
       refreshJobs();
     });

--- a/jobs.js
+++ b/jobs.js
@@ -304,15 +304,15 @@ const jobFields = {
       ['Chief Transportation Officer', 110000, 'university']
     ]
   },
-  influencer: {
+  celebrity: {
     entry: [
-      ['Micro Influencer', 30000, 'none', null, 1000]
+      ['Influencer', 40000, 'none', null, 30]
     ],
     mid: [
-      ['Social Media Star', 70000, 'none', null, 10000]
+      ['Musician', 80000, 'none', null, 60]
     ],
     senior: [
-      ['Celebrity Influencer', 150000, 'none', null, 100000]
+      ['Actor', 150000, 'none', null, 100]
     ]
   },
   freelance: [
@@ -328,7 +328,7 @@ export const freelanceJobs = jobFields.freelance;
 
 const fieldDiscoveryYear = {
   technology: 1940,
-  influencer: 2005
+  celebrity: 1950
 };
 
 const jobDiscoveryYear = {
@@ -357,7 +357,7 @@ for (const [field, levels] of Object.entries(jobFields)) {
   if (Array.isArray(levels)) continue;
   const fieldYear = fieldDiscoveryYear[field] || 0;
   for (const [level, jobs] of Object.entries(levels)) {
-    for (const [title, base, edu, major, followers] of jobs) {
+    for (const [title, base, edu, major, fame] of jobs) {
       const availableFrom = jobDiscoveryYear[title] || fieldYear;
       allJobs.push({
         field,
@@ -366,7 +366,7 @@ for (const [field, levels] of Object.entries(jobFields)) {
         base,
         reqEdu: edu,
         reqMajor: major,
-        reqFollowers: followers,
+        reqFame: fame,
         tuitionAssistance: ['education', 'healthcare', 'law'].includes(field),
         availableFrom
       });
@@ -403,7 +403,10 @@ export function generateJobs() {
   const count = phase === 'boom' ? 8 : phase === 'recession' ? 4 : 6;
   const mod = phase === 'boom' ? 1.2 : phase === 'recession' ? 0.8 : 1;
   const jobPool = allJobs.filter(
-    j => j.availableFrom <= game.year && (!j.reqMajor || j.reqMajor === game.major) && (!j.reqFollowers || j.reqFollowers <= game.followers)
+    j =>
+      j.availableFrom <= game.year &&
+      (!j.reqMajor || j.reqMajor === game.major) &&
+      (!j.reqFame || j.reqFame <= game.fame)
   );
   for (let i = 0; i < count && jobPool.length; i++) {
     const job = jobPool[rand(0, jobPool.length - 1)];
@@ -413,7 +416,7 @@ export function generateJobs() {
       salary,
       reqEdu: job.reqEdu,
       reqMajor: job.reqMajor,
-      reqFollowers: job.reqFollowers,
+      reqFame: job.reqFame,
       field: job.field,
       level: job.level,
       tuitionAssistance: job.tuitionAssistance

--- a/state.js
+++ b/state.js
@@ -67,6 +67,8 @@ export const game = {
   loanInterestRate: 0.05,
   followers: 0,
   lastPost: 0,
+  fame: 0,
+  fameBonus: 0,
   reputation: 50,
   charityTotal: 0,
   charityYear: 0,
@@ -175,11 +177,16 @@ export function addLog(text, category = 'general') {
   refreshOpenWindows();
 }
 
+export function updateFame() {
+  game.fame = Math.floor(game.followers / 1000) + game.achievements.length * 10 + game.fameBonus;
+}
+
 export function unlockAchievement(id) {
   if (game.achievements.some(a => a.id === id)) return;
   const text = ACHIEVEMENTS[id] || id;
   game.achievements.push({ id, text });
   addLog(`Achievement unlocked: ${text}`, 'achievement');
+  updateFame();
   saveGame();
 }
 
@@ -349,6 +356,8 @@ export function newLife(genderInput, nameInput, options = {}) {
     loanInterestRate: 0.05,
     followers: 0,
     lastPost: 0,
+    fame: 0,
+    fameBonus: 0,
     reputation: 50,
     charityTotal: 0,
     charityYear: 0,
@@ -397,6 +406,7 @@ export function newLife(genderInput, nameInput, options = {}) {
     },
     log: []
   });
+  updateFame();
   initBrokers().then(refreshOpenWindows);
   if (!options.skipBirthLog) {
     addLog([


### PR DESCRIPTION
## Summary
- track player fame from followers and achievements with recalculation helper
- add celebrity job field (influencer, musician, actor) gated by fame
- let viral posts and scandals boost fame on social media

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba1a2e9270832abf1598bba584314b