### PR TITLE
Add political career activity and job tiers

### DIFF
--- a/activities/politics.js
+++ b/activities/politics.js
@@ -1,0 +1,43 @@
+import { game, addLog, applyAndSave } from '../state.js';
+import { rand, clamp } from '../utils.js';
+
+const OFFICES = [
+  { title: 'Council Member', cost: 20000, rep: 40 },
+  { title: 'Mayor', cost: 100000, rep: 60 }
+];
+
+export function renderPolitics(container) {
+  const wrap = document.createElement('div');
+
+  const head = document.createElement('div');
+  head.className = 'muted';
+  head.textContent = 'Run for office using your reputation and funds.';
+  wrap.appendChild(head);
+
+  for (const office of OFFICES) {
+    const btn = document.createElement('button');
+    btn.className = 'btn block';
+    btn.textContent = `${office.title} - $${office.cost.toLocaleString()}`;
+    if (game.money < office.cost) {
+      btn.disabled = true;
+    }
+    btn.addEventListener('click', () => {
+      if (game.money < office.cost) return;
+      applyAndSave(() => {
+        game.money -= office.cost;
+        const chance = clamp(game.reputation - office.rep + 50, 5, 95);
+        const won = rand(1, 100) <= chance;
+        if (won) {
+          game.politicalCareer = office.title;
+          addLog(`You were elected ${office.title}.`, 'politics');
+        } else {
+          addLog(`You lost the ${office.title} election.`, 'politics');
+        }
+      });
+    });
+    wrap.appendChild(btn);
+  }
+
+  container.appendChild(wrap);
+}
+

--- a/jobs.js
+++ b/jobs.js
@@ -242,6 +242,17 @@ const jobFields = {
       ['Agency Director', 115000, 'university']
     ]
   },
+  politics: {
+    entry: [
+      ['Campaign Staffer', 25000, 'none']
+    ],
+    mid: [
+      ['Council Member', 60000, 'college']
+    ],
+    senior: [
+      ['Mayor', 120000, 'university']
+    ]
+  },
   science: {
     entry: [
       ['Lab Technician', 34000, 'college'],

--- a/renderers/activities.js
+++ b/renderers/activities.js
@@ -70,7 +70,8 @@ const ACTIVITIES_CATEGORIES = {
   'Travel & Community': [
     'Commune',
     'Emigrate',
-    'Charity'
+    'Charity',
+    'Politics'
   ],
   'Business & Finance': ['Business']
 };
@@ -120,6 +121,7 @@ const ACTIVITY_ICONS = {
   Commune: '🏘️',
   Emigrate: '✈️',
   Charity: '💝',
+  Politics: '🗳️',
   Prison: '🚔',
   Business: '💼'
 };
@@ -176,6 +178,7 @@ const ACTIVITY_RENDERERS = {
   'Car Dealership': () => openActivity('carDealership', 'Car Dealership', '../activities/carDealership.js', 'renderCarDealership'),
   'Car Maintenance': () => openActivity('carMaintenance', 'Car Maintenance', '../activities/carMaintenance.js', 'renderCarMaintenance'),
   Charity: () => openActivity('charity', 'Charity', '../activities/charity.js', 'renderCharity'),
+  Politics: () => openActivity('politics', 'Politics', '../activities/politics.js', 'renderPolitics'),
   Business: () => openActivity('business', 'Business', '../activities/business.js', 'renderBusiness')
 };
 

--- a/state.js
+++ b/state.js
@@ -86,6 +86,7 @@ export const game = {
   unemployment: 0,
   jobListings: [],
   jobListingsYear: null,
+  politicalCareer: null,
   relationships: [],
   children: [],
   parents: {
@@ -368,6 +369,7 @@ export function newLife(genderInput, nameInput, options = {}) {
     unemployment: 0,
     jobListings: [],
     jobListingsYear: null,
+    politicalCareer: null,
     relationships: [],
     children: [],
     parents: options.parents ?? {


### PR DESCRIPTION
## Summary
- add politics activity to run for offices using reputation and campaign funds
- introduce political job track with campaign staffer, council member, and mayor roles
- track `politicalCareer` state and expose politics in activity menu

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba1a2bd4b8832a9d1558b43a8b6e78