### PR TITLE
Remove duplicate siblings property from game state

### DIFF
--- a/state.js
+++ b/state.js
@@ -114,7 +114,6 @@ export const game = {
   maritalStatus: 'single',
   spouse: null,
   children: [],
-  siblings: [],
   parents: {
     mother,
     father


### PR DESCRIPTION
## Summary
- remove redundant `siblings` entry in the main `game` object so it only appears once

## Testing
- `npm test` *(fails: SyntaxError: 'import' and 'export' may only appear at the top level)*

------
https://chatgpt.com/codex/tasks/task_e_68ba234e9050832ab9d6b9643ce7dafd