### PR TITLE
Remove duplicate siblings initialization

### DIFF
--- a/state.js
+++ b/state.js
@@ -483,7 +483,6 @@ export function newLife(genderInput, nameInput, options = {}) {
     jobListingsYear: null,
     politicalCareer: null,
     relationships: [],
-    siblings: [],
     maritalStatus: 'single',
     spouse: null,
     children: [],


### PR DESCRIPTION
## Summary
- avoid double `siblings` assignment when creating new life state

## Testing
- `npm test` *(fails: Jest encountered an unexpected token)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2351bb7c832aa905b64f3fd19f5d