### PR TITLE
fix: check for cars when commuting

### DIFF
--- a/actions/job.js
+++ b/actions/job.js
@@ -5,7 +5,7 @@ const { adjustJobPerformance, generateJobs } = jobs;
 import { checkForAccident } from './traffic.js';
 
 function commute() {
-  if (game.car) {
+  if (game.cars && game.cars.length) {
     checkForAccident();
   }
 }


### PR DESCRIPTION
## Summary
- ensure commute only runs accident checks when player owns cars

## Testing
- `npm test` *(fails: Test environment jest-environment-jsdom cannot be found; SyntaxError 'import' and 'export' may only appear at the top level)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2353c91c832a8105927292b4508b