### PR TITLE
Reset parole status in new life

### DIFF
--- a/state.js
+++ b/state.js
@@ -509,6 +509,8 @@ export function newLife(genderInput, nameInput, options = {}) {
     country,
     sick: false,
     inJail: false,
+    onParole: false,
+    paroleYears: 0,
     gang: null,
     alive: true,
     diseases: [],


### PR DESCRIPTION
## Summary
- Ensure `newLife` reinitializes parole status by adding `onParole` and `paroleYears` fields after `inJail`.

## Testing
- `npm test` *(fails: Jest environment and parsing issues)*

------
https://chatgpt.com/codex/tasks/task_e_68ba235a0acc832aaa8cedb7511451f5