### PR TITLE
feat: allow achievement descriptions

### DIFF
--- a/actions/family.js
+++ b/actions/family.js
@@ -1,6 +1,9 @@
 import { game, addLog, saveGame, applyAndSave, unlockAchievement } from '../state.js';
 import { rand, clamp } from '../utils.js';
 
+const FIRST_CHILD_DESC = 'Had your first child.';
+const HAPPY_CHILD_DESC = 'Raised a very happy child.';
+
 export function hostFamilyGathering() {
   if (!game.alive) return;
   if (!game.relationships || game.relationships.length === 0) {
@@ -40,7 +43,7 @@ export function haveChild() {
       'You became a parent to a newborn.'
     ], 'family');
     if (game.children.length === 1) {
-      unlockAchievement('first-child', 'Had your first child.');
+      unlockAchievement('first-child', FIRST_CHILD_DESC);
     }
   });
 }
@@ -56,7 +59,7 @@ export function spendTimeWithChild(index = 0) {
       'Bonding with your child made them happier. (+Child Happiness)'
     ], 'family');
     if (child.happiness >= 90) {
-      unlockAchievement('happy-child', 'Raised a very happy child.');
+      unlockAchievement('happy-child', HAPPY_CHILD_DESC);
     }
   });
 }

--- a/state.js
+++ b/state.js
@@ -227,9 +227,9 @@ export function distributeInheritance(relative) {
   );
 }
 
-export function unlockAchievement(id) {
+export function unlockAchievement(id, description) {
   if (game.achievements.some(a => a.id === id)) return;
-  const text = ACHIEVEMENTS[id] || id;
+  const text = description || ACHIEVEMENTS[id] || id;
   game.achievements.push({ id, text });
   addLog(`Achievement unlocked: ${text}`, 'achievement');
   updateFame();


### PR DESCRIPTION
## Summary
- allow achievements to supply custom descriptions via `unlockAchievement`
- use constants when unlocking child-related achievements

## Testing
- `npm test` *(fails: module resolution and syntax errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ba235f5490832ab13f004ddb0a74ba