### PR TITLE
Guard close all button listener

### DIFF
--- a/script.js
+++ b/script.js
@@ -159,9 +159,12 @@ document.querySelectorAll(`[data-toggle="newLife"]`).forEach(btn => {
     openWindow('newLife', 'New Life', renderNewLife);
   });
 });
-document.getElementById('closeAll').addEventListener('click', () => {
-  closeAllWindows();
-});
+const closeAllBtn = document.getElementById('closeAll');
+if (closeAllBtn) {
+  closeAllBtn.addEventListener('click', () => {
+    closeAllWindows();
+  });
+}
 
 themeToggle.addEventListener('click', () => {
   theme = theme === 'dark' ? 'light' : 'dark';


### PR DESCRIPTION
## Summary
- Store the close-all button element before use and guard addEventListener with null check

## Testing
- `npm test` *(fails: bash: command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2360d1ac832a9f9d27f2366d8865