### PR TITLE
fix: guard theme toggle handler

### DIFF
--- a/script.js
+++ b/script.js
@@ -163,10 +163,12 @@ document.getElementById('closeAll').addEventListener('click', () => {
   closeAllWindows();
 });
 
-themeToggle.addEventListener('click', () => {
-  theme = theme === 'dark' ? 'light' : 'dark';
-  setTheme(theme);
-});
+if (themeToggle) {
+  themeToggle.addEventListener('click', () => {
+    theme = theme === 'dark' ? 'light' : 'dark';
+    setTheme(theme);
+  });
+}
 
 const activeSlot = getCurrentSlot();
 const slots = listSlots();


### PR DESCRIPTION
## Summary
- avoid errors if the theme toggle element is missing

## Testing
- `npm test` *(fails: SyntaxError: 'import' and 'export' may only appear at the top level)*

------
https://chatgpt.com/codex/tasks/task_e_68ba236310e8832aa2e170966c8b549e