### PR TITLE
Fix job pool filtering conditions

### DIFF
--- a/jobs.js
+++ b/jobs.js
@@ -445,9 +445,8 @@ export function generateJobs() {
       j.availableFrom <= game.year &&
       (!j.reqMajor || j.reqMajor === game.major) &&
       (!j.reqFollowers || j.reqFollowers <= game.followers) &&
-      (!j.reqEnlisted || game.military?.enlisted)
-      (!j.reqFame || j.reqFame <= game.fame)
-      (!j.reqFollowers || j.reqFollowers <= game.followers) &&
+      (!j.reqEnlisted || game.military?.enlisted) &&
+      (!j.reqFame || j.reqFame <= game.fame) &&
       (!j.reqFitness || j.reqFitness <= game.skills.fitness)
   );
   for (let i = 0; i < count && jobPool.length; i++) {


### PR DESCRIPTION
## Summary
- Ensure fame requirement is correctly chained in job filter
- Remove duplicated follower requirement in job selection logic

## Testing
- `npm test` *(fails: Jest encountered unexpected token parsing ES modules and reported 12 failing test suites)*

------
https://chatgpt.com/codex/tasks/task_e_68ba236778d4832a938bf188ab726203