### PR TITLE
Add category for property tax logs

### DIFF
--- a/realestate.js
+++ b/realestate.js
@@ -313,7 +313,7 @@ export function tickRealEstate() {
     prop.value = Math.round(prop.value * factor);
     const tax = Math.round(prop.value * 0.01);
     game.money -= tax;
-    addLog(`Paid $${tax.toLocaleString()} in property tax for ${prop.name}.`);
+      addLog(`Paid $${tax.toLocaleString()} in property tax for ${prop.name}.`, 'property');
     if (prop.mortgage) {
       let paid = 0;
       for (let m = 0; m < 12; m++) {


### PR DESCRIPTION
## Summary
- categorize property tax log entries as `property`

## Testing
- `npm test 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68ba2369f928832a81e9d01d762c6534