### PR TITLE
Initialize siblings randomly

### DIFF
--- a/state.js
+++ b/state.js
@@ -110,11 +110,10 @@ export const game = {
   jobListingsYear: null,
   politicalCareer: null,
   relationships: [],
-  siblings: [],
+  siblings: randomSiblings(),
   maritalStatus: 'single',
   spouse: null,
   children: [],
-  siblings: [],
   parents: {
     mother,
     father
@@ -483,13 +482,12 @@ export function newLife(genderInput, nameInput, options = {}) {
     jobListingsYear: null,
     politicalCareer: null,
     relationships: [],
-    siblings: [],
     maritalStatus: 'single',
     spouse: null,
     children: [],
     pets: [], // { type, breed, talent, age, happiness, health, alive }
     petMemorials: [],
-    siblings: options.siblings ?? [],
+    siblings: options.siblings ?? randomSiblings(),
     parents: options.parents ?? {
       mother: newMother,
       father: newFather


### PR DESCRIPTION
## Summary
- Generate initial siblings using `randomSiblings()` in base game state
- Populate siblings with `randomSiblings()` when starting a new life

## Testing
- `npm test` *(fails: Test Suites: 12 failed, 6 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ba235c490c832ab5751ce16bc09b20