### PR TITLE
Fix job field parsing and consolidate job generation loops

### DIFF
--- a/jobs.js
+++ b/jobs.js
@@ -325,7 +325,7 @@ const jobFields = {
     senior: [
       ['Officer', 60000, 'college', null, null, true]
     ]
-  }
+  },
   sports: {
     entry: [
       ['Minor League Player', 40000, 'none', null, null, 70]
@@ -390,24 +390,37 @@ for (const [field, levels] of Object.entries(jobFields)) {
   if (Array.isArray(levels)) continue;
   const fieldYear = fieldDiscoveryYear[field] || 0;
   for (const [level, jobs] of Object.entries(levels)) {
-    for (const [title, base, edu, major, followers, enlist] of jobs) {
-    for (const [title, base, edu, major, fame] of jobs) {
-    for (const [title, base, edu, major, followers, fitness] of jobs) {
+    for (const job of jobs) {
+      const [
+        title,
+        base,
+        edu,
+        major,
+        fameOrFollowers,
+        fitnessOrEnlisted
+      ] = job;
       const availableFrom = jobDiscoveryYear[title] || fieldYear;
-      allJobs.push({
+      const entry = {
         field,
         level,
         title,
         base,
         reqEdu: edu,
         reqMajor: major,
-        reqFame: fame,
-        reqFollowers: followers,
-        reqEnlisted: enlist,
-        reqFitness: fitness,
         tuitionAssistance: ['education', 'healthcare', 'law'].includes(field),
         availableFrom
-      });
+      };
+      if (job.length === 5) {
+        entry.reqFame = fameOrFollowers;
+      } else if (job.length === 6) {
+        if (fameOrFollowers != null) entry.reqFollowers = fameOrFollowers;
+        if (typeof fitnessOrEnlisted === 'boolean') {
+          entry.reqEnlisted = fitnessOrEnlisted;
+        } else {
+          entry.reqFitness = fitnessOrEnlisted;
+        }
+      }
+      allJobs.push(entry);
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add missing comma after the `military` jobs block so the `sports` field parses correctly.
- Consolidate three duplicate loops into a single job aggregation loop that handles fame, follower, enlistment, and fitness requirements.
- Replace placeholder variables with descriptive names to clarify optional job requirement handling.

## Testing
- `npm test` *(fails: SyntaxError in tests/activities.love.test.js; Test Suites: 4 failed, 14 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2595f5bc832aa7051d215ff85ef7