### PR TITLE
Add window transparency slider

### DIFF
--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -9,12 +9,41 @@ export function setTheme(theme) {
   localStorage.setItem('theme', theme);
 }
 
+let transparencySlider;
+
 export function setWindowTransparency(solid) {
   const transparencyToggle = document.getElementById('transparencyToggle');
   document.body.classList.toggle('solid-windows', solid);
   if (transparencyToggle) {
     transparencyToggle.textContent = solid ? '⬛' : '🔲';
     transparencyToggle.setAttribute('aria-pressed', String(solid));
+    if (!solid) {
+      if (!transparencySlider) {
+        transparencySlider = document.createElement('input');
+        transparencySlider.type = 'range';
+        transparencySlider.min = '0.2';
+        transparencySlider.max = '1';
+        transparencySlider.step = '0.01';
+        transparencySlider.style.marginLeft = '8px';
+        const stored = parseFloat(localStorage.getItem('windowOpacity')) || 0.92;
+        transparencySlider.value = String(stored);
+        transparencySlider.addEventListener('input', e => {
+          const value = e.target.value;
+          document.documentElement.style.setProperty('--window-opacity', value);
+          localStorage.setItem('windowOpacity', value);
+        });
+      }
+      const stored = parseFloat(localStorage.getItem('windowOpacity')) || parseFloat(transparencySlider.value);
+      document.documentElement.style.setProperty('--window-opacity', String(stored));
+      transparencyToggle.after(transparencySlider);
+    } else if (transparencySlider) {
+      transparencySlider.remove();
+      document.documentElement.style.setProperty('--window-opacity', '1');
+    }
+  }
+  if (!solid) {
+    const value = transparencySlider ? transparencySlider.value : '0.92';
+    localStorage.setItem('windowOpacity', value);
   }
   localStorage.setItem('solidWindows', solid ? '1' : '0');
 }

--- a/styles/components.css
+++ b/styles/components.css
@@ -17,7 +17,7 @@
   position:absolute; min-width: 280px; max-width: 520px; width: 380px; border-radius: var(--radius);
   background: linear-gradient(180deg, var(--glass-2), var(--glass));
   border: 1px solid var(--stroke); box-shadow: var(--shadow); overflow: hidden;
-  user-select: none; opacity: .92;
+  user-select: none; opacity: var(--window-opacity, .92);
   max-height: 80vh;
   display: flex;
   flex-direction: column;
@@ -35,12 +35,15 @@
 .control-btn:hover{ color: var(--text); border-color: rgba(255,255,255,.35); }
 .content{ padding: 12px; backdrop-filter: blur(2px); overflow:auto; flex:1; }
 
-.window.active{ opacity: 1; border-color: rgba(255,255,255,.55); box-shadow: var(--shadow-strong); }
+.window.active{ border-color: rgba(255,255,255,.55); box-shadow: var(--shadow-strong); }
 .window:not(.active) .titlebar{ background: linear-gradient(180deg, rgba(255,255,255,.05), rgba(255,255,255,.01)); }
+
+body.solid-windows{
+  --window-opacity: 1;
+}
 
 body.solid-windows .window{
   background: var(--surface);
-  opacity: 1;
 }
 
 body.solid-windows .window .titlebar{


### PR DESCRIPTION
## Summary
- Add a range slider that appears when enabling transparency to control window opacity
- Store chosen opacity in localStorage and apply via CSS variable
- Replace fixed opacity with `--window-opacity` variable and reset for solid windows

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68baa666ef80832a8c3a8ce5d8a4e1a3