### PR TITLE
Adjust transparency slider to control background blur

### DIFF
--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -12,6 +12,8 @@ export function setTheme(theme) {
 let transparencySlider;
 
 export function setWindowTransparency(solid) {
+  const stored = parseFloat(localStorage.getItem('windowBlur')) || 2;
+  document.documentElement.style.setProperty('--window-blur', `${stored}px`);
   const transparencyToggle = document.getElementById('transparencyToggle');
   document.body.classList.toggle('solid-windows', solid);
   if (transparencyToggle) {
@@ -21,29 +23,31 @@ export function setWindowTransparency(solid) {
       if (!transparencySlider) {
         transparencySlider = document.createElement('input');
         transparencySlider.type = 'range';
-        transparencySlider.min = '0.2';
-        transparencySlider.max = '1';
-        transparencySlider.step = '0.01';
+        transparencySlider.min = '0';
+        transparencySlider.max = '10';
+        transparencySlider.step = '0.5';
         transparencySlider.style.marginLeft = '8px';
-        const stored = parseFloat(localStorage.getItem('windowOpacity')) || 0.92;
+        transparencySlider.setAttribute('aria-label', 'Adjust background blur');
+        transparencySlider.title = 'Adjust background blur';
         transparencySlider.value = String(stored);
         transparencySlider.addEventListener('input', e => {
           const value = e.target.value;
-          document.documentElement.style.setProperty('--window-opacity', value);
-          localStorage.setItem('windowOpacity', value);
+          document.documentElement.style.setProperty('--window-blur', `${value}px`);
+          localStorage.setItem('windowBlur', value);
         });
       }
-      const stored = parseFloat(localStorage.getItem('windowOpacity')) || parseFloat(transparencySlider.value);
-      document.documentElement.style.setProperty('--window-opacity', String(stored));
       transparencyToggle.after(transparencySlider);
-    } else if (transparencySlider) {
-      transparencySlider.remove();
+      document.documentElement.style.removeProperty('--window-opacity');
+    } else {
       document.documentElement.style.setProperty('--window-opacity', '1');
+      if (transparencySlider) {
+        transparencySlider.remove();
+      }
     }
   }
   if (!solid) {
-    const value = transparencySlider ? transparencySlider.value : '0.92';
-    localStorage.setItem('windowOpacity', value);
+    const value = transparencySlider ? transparencySlider.value : String(stored);
+    localStorage.setItem('windowBlur', value);
   }
   localStorage.setItem('solidWindows', solid ? '1' : '0');
 }

--- a/styles/components.css
+++ b/styles/components.css
@@ -2,7 +2,7 @@
 .dock{
   position: fixed; left: 0; right: 0; top: 0; height: 54px; display:flex; gap:10px; align-items:center; padding: 8px 12px;
   background: linear-gradient(180deg, rgba(12,16,30,.8), rgba(12,16,30,.35));
-  border-bottom: 1px solid var(--stroke); backdrop-filter: blur(8px);
+  border-bottom: 1px solid var(--stroke); backdrop-filter: blur(calc(var(--window-blur, 2px) * 4));
 }
 .dock .title { font-weight:700; letter-spacing: .4px; margin-right: 8px; opacity:.9 }
 .dock button{
@@ -33,7 +33,7 @@
 .control-btn{ width: 26px; height: 26px; border-radius: 8px; display:grid; place-items:center; border:1px solid var(--stroke);
   background: linear-gradient(180deg, rgba(255,255,255,.10), rgba(255,255,255,.04)); color: var(--muted); cursor: pointer; }
 .control-btn:hover{ color: var(--text); border-color: rgba(255,255,255,.35); }
-.content{ padding: 12px; backdrop-filter: blur(2px); overflow:auto; flex:1; }
+.content{ padding: 12px; backdrop-filter: blur(var(--window-blur, 2px)); overflow:auto; flex:1; }
 
 .window.active{ border-color: rgba(255,255,255,.55); box-shadow: var(--shadow-strong); }
 .window:not(.active) .titlebar{ background: linear-gradient(180deg, rgba(255,255,255,.05), rgba(255,255,255,.01)); }

--- a/styles/variables.css
+++ b/styles/variables.css
@@ -13,6 +13,7 @@
   --shadow: 0 10px 40px rgba(0,0,0,0.45);
   --shadow-strong: 0 14px 60px rgba(0,0,0,0.65);
   --radius: 14px;
+  --window-blur: 2px;
 }
 
 body.dark{
@@ -27,4 +28,5 @@ body.dark{
   --good: #5acb64;
   --bad: #ff6565;
   --warn: #ffc955;
+  --window-blur: 2px;
 }


### PR DESCRIPTION
## Summary
- Use a new `--window-blur` CSS variable for window background blur
- Change transparency slider to adjust blur instead of window opacity
- Apply blur variable to dock and window content styles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc3ab35bc0832aae1587fd9f0cdf81