### PR TITLE
feat: centralize task chance configuration

### DIFF
--- a/scripts/actions/crime.js
+++ b/scripts/actions/crime.js
@@ -1,5 +1,6 @@
 import { game, addLog, saveGame, applyAndSave } from '../state.js';
 import { rand, clamp } from '../utils.js';
+import { taskChances } from '../taskChances.js';
 
 export function crime() {
   if (game.inJail) {
@@ -30,10 +31,10 @@ export function crime() {
   }
   applyAndSave(() => {
     const crimes = [
-      { name: 'Pickpocket', risk: 12, reward: [50, 180] },
-      { name: 'Shoplift', risk: 18, reward: [80, 400] },
-      { name: 'Car theft', risk: 35, reward: [800, 6000] },
-      { name: 'Bank robbery', risk: 60, reward: [5000, 45000] }
+      { name: 'Pickpocket', risk: taskChances.crime.pickpocket, reward: [50, 180] },
+      { name: 'Shoplift', risk: taskChances.crime.shoplift, reward: [80, 400] },
+      { name: 'Car theft', risk: taskChances.crime.carTheft, reward: [800, 6000] },
+      { name: 'Bank robbery', risk: taskChances.crime.bankRobbery, reward: [5000, 45000] }
     ];
     const c = crimes[rand(0, crimes.length - 1)];
     let risk = c.risk;

--- a/scripts/activities/gamble.js
+++ b/scripts/activities/gamble.js
@@ -1,6 +1,7 @@
 import { game, addLog, applyAndSave } from '../state.js';
 import { rand } from '../utils.js';
 import { openWindow } from '../windowManager.js';
+import { taskChances } from '../taskChances.js';
 
 export { openWindow };
 
@@ -98,7 +99,7 @@ export function renderGamble(container) {
       } else if (selectedGame === 'roulette') {
         const colorSelect = gameOptions.querySelector('select');
         const choice = colorSelect.value;
-        const chance = Math.min(48 + game.skills.gambling, 90);
+        const chance = Math.min(taskChances.gamble.rouletteBase + game.skills.gambling, 90);
         const winRoll = rand(1, 100) <= chance;
         const wheel = winRoll ? choice : choice === 'red' ? 'black' : 'red';
         win = winRoll;

--- a/scripts/activities/racing.js
+++ b/scripts/activities/racing.js
@@ -1,5 +1,6 @@
 import { game, addLog, applyAndSave } from '../state.js';
 import { rand, clamp } from '../utils.js';
+import { taskChances } from '../taskChances.js';
 
 export function renderRacing(container) {
   const wrap = document.createElement('div');
@@ -14,7 +15,7 @@ export function renderRacing(container) {
   vehicleBtn.textContent = 'Race Vehicles';
   vehicleBtn.addEventListener('click', () => {
     applyAndSave(() => {
-      const chance = Math.min(50 + game.skills.racing, 90);
+      const chance = Math.min(taskChances.racing.vehicleBase + game.skills.racing, 90);
       if (rand(1, 100) <= chance) {
         const prize = rand(200, 500) + game.skills.racing * 10;
         game.money += prize;
@@ -36,7 +37,7 @@ export function renderRacing(container) {
   footBtn.textContent = 'Race on Foot';
   footBtn.addEventListener('click', () => {
     applyAndSave(() => {
-      const chance = Math.min(50 + game.skills.racing, 90);
+      const chance = Math.min(taskChances.racing.footBase + game.skills.racing, 90);
       if (rand(1, 100) <= chance) {
         const gain = rand(5, 10) + Math.floor(game.skills.racing / 5);
         game.health = clamp(game.health + gain);

--- a/scripts/realestate.js
+++ b/scripts/realestate.js
@@ -1,6 +1,7 @@
 import { game, addLog, saveGame, unlockAchievement } from './state.js';
 import { rand, clamp } from './utils.js';
 import { getFaker } from './utils/faker.js';
+import { taskChances } from './taskChances.js';
 
 const faker = await getFaker();
 
@@ -283,12 +284,13 @@ export function repairProperty(prop, percent) {
     return;
   }
   game.money -= cost;
-  let chance = 0;
-  if (percent === 10) chance = 40;
-  else if (percent === 25) chance = 60;
-  else if (percent === 50) chance = 80;
-  else if (percent === 100) chance = 95;
-  else chance = Math.min(95, percent);
+  const chanceMap = {
+    10: taskChances.realEstate.repair10,
+    25: taskChances.realEstate.repair25,
+    50: taskChances.realEstate.repair50,
+    100: taskChances.realEstate.repair100
+  };
+  const chance = chanceMap[percent] ?? Math.min(95, percent);
   const roll = rand(1, 100);
   if (roll <= chance) {
     prop.condition = 100;

--- a/scripts/taskChances.js
+++ b/scripts/taskChances.js
@@ -1,0 +1,29 @@
+export const taskChances = {
+  // Crime action base risk percentages
+  crime: {
+    pickpocket: 12, // Pickpocket risk
+    shoplift: 18, // Shoplift risk
+    carTheft: 35, // Car theft risk
+    bankRobbery: 60 // Bank robbery risk
+  },
+
+  // Gambling activities
+  gamble: {
+    rouletteBase: 48 // Base chance to win roulette
+  },
+
+  // Racing activities
+  racing: {
+    vehicleBase: 50, // Base chance to win a vehicle race
+    footBase: 50 // Base chance to win a foot race
+  },
+
+  // Real estate repairs
+  realEstate: {
+    repair10: 40, // Success chance for 10% repair investment
+    repair25: 60, // Success chance for 25% repair investment
+    repair50: 80, // Success chance for 50% repair investment
+    repair100: 95 // Success chance for full repair investment
+  }
+};
+


### PR DESCRIPTION
## Summary
- add `taskChances` module to centralize default chance values for crime, gambling, racing and real estate repairs
- refactor task modules to use shared configuration instead of hardcoded numbers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdc3f306c8832a9fff919345c20827