### PR TITLE
fix: ensure blur slider affects windows

### DIFF
--- a/styles/components.css
+++ b/styles/components.css
@@ -2,7 +2,9 @@
 .dock{
   position: fixed; left: 0; right: 0; top: 0; height: 54px; display:flex; gap:10px; align-items:center; padding: 8px 12px;
   background: linear-gradient(180deg, rgba(12,16,30,.8), rgba(12,16,30,.35));
-  border-bottom: 1px solid var(--stroke); backdrop-filter: blur(calc(var(--window-blur, 2px) * 4));
+  border-bottom: 1px solid var(--stroke);
+  backdrop-filter: blur(calc(var(--window-blur, 2px) * 4));
+  -webkit-backdrop-filter: blur(calc(var(--window-blur, 2px) * 4));
 }
 .dock .title { font-weight:700; letter-spacing: .4px; margin-right: 8px; opacity:.9 }
 .dock button{
@@ -33,7 +35,13 @@
 .control-btn{ width: 26px; height: 26px; border-radius: 8px; display:grid; place-items:center; border:1px solid var(--stroke);
   background: linear-gradient(180deg, rgba(255,255,255,.10), rgba(255,255,255,.04)); color: var(--muted); cursor: pointer; }
 .control-btn:hover{ color: var(--text); border-color: rgba(255,255,255,.35); }
-.content{ padding: 12px; backdrop-filter: blur(var(--window-blur, 2px)); overflow:auto; flex:1; }
+.content{
+  padding: 12px;
+  backdrop-filter: blur(var(--window-blur, 2px));
+  -webkit-backdrop-filter: blur(var(--window-blur, 2px));
+  overflow:auto;
+  flex:1;
+}
 
 .window.active{ border-color: rgba(255,255,255,.55); box-shadow: var(--shadow-strong); }
 .window:not(.active) .titlebar{ background: linear-gradient(180deg, rgba(255,255,255,.05), rgba(255,255,255,.01)); }
@@ -52,6 +60,7 @@ body.solid-windows .window .titlebar{
 
 body.solid-windows .window .content{
   backdrop-filter: none;
+  -webkit-backdrop-filter: none;
 }
 
 .grid{ display: grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap: 10px; }


### PR DESCRIPTION
## Summary
- ensure window blur slider works in more browsers by adding `-webkit-backdrop-filter`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdca5c4600832a88794482779130af