### PR TITLE
feat: persist lottery selection

### DIFF
--- a/scripts/activities/lottery.js
+++ b/scripts/activities/lottery.js
@@ -77,7 +77,7 @@ export function renderScratchOff(container) {
   container.appendChild(wrap);
 }
 
-export function renderLottery(container) {
+export function renderLottery(container, win) {
   const wrap = document.createElement('div');
 
   const select = document.createElement('select');
@@ -90,6 +90,11 @@ export function renderLottery(container) {
   optScratch.textContent = 'Scratch-Off Ticket';
   select.appendChild(optScratch);
   wrap.appendChild(select);
+
+  select.value = win?.dataset.lotteryType || 'standard';
+  if (win) {
+    win.dataset.lotteryType = select.value;
+  }
 
   const content = document.createElement('div');
   content.style.marginTop = '8px';
@@ -104,7 +109,12 @@ export function renderLottery(container) {
     }
   };
 
-  select.addEventListener('change', renderCurrent);
+  select.addEventListener('change', () => {
+    if (win) {
+      win.dataset.lotteryType = select.value;
+    }
+    renderCurrent();
+  });
   renderCurrent();
 
   container.appendChild(wrap);

--- a/tests/activities.lottery.test.js
+++ b/tests/activities.lottery.test.js
@@ -1,0 +1,37 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from '@jest/globals';
+
+const game = { money: 10, happiness: 0, log: [] };
+const addLog = jest.fn();
+const applyAndSave = fn => fn();
+
+await jest.unstable_mockModule('../scripts/state.js', () => ({
+  game,
+  addLog,
+  applyAndSave,
+  saveGame: jest.fn()
+}));
+
+const { renderLottery } = await import('../scripts/activities/lottery.js');
+
+test('keeps selected option after refresh', () => {
+  const container = document.createElement('div');
+  const win = document.createElement('div');
+
+  renderLottery(container, win);
+
+  const select = container.querySelector('select');
+  expect(select.value).toBe('standard');
+
+  select.value = 'scratch';
+  select.dispatchEvent(new Event('change'));
+
+  container.innerHTML = '';
+  renderLottery(container, win);
+  const select2 = container.querySelector('select');
+  expect(select2.value).toBe('scratch');
+});
+


### PR DESCRIPTION
## Summary
- store selected lottery ticket type in window state to survive refreshes
- test that lottery dropdown keeps the chosen option after betting

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be1576af64832a90ec017262ac9234