### PR TITLE
Guard against missing process in browser

### DIFF
--- a/scripts/actions/ageUp.js
+++ b/scripts/actions/ageUp.js
@@ -48,7 +48,8 @@ function progressDiseases() {
 }
 
 function randomEvent() {
-  const testing = process.env.NODE_ENV === 'test';
+  const testing =
+    typeof process !== 'undefined' && process.env && process.env.NODE_ENV === 'test';
   if (game.age === 5 && (testing || rand(1, 100) <= taskChances.ageUp.learnToRead)) {
     addLog(
       [

--- a/scripts/actions/property.js
+++ b/scripts/actions/property.js
@@ -2,6 +2,9 @@ import { game, addLog } from '../state.js';
 import { rand } from '../utils.js';
 import { taskChances } from '../taskChances.js';
 
+const testing =
+  typeof process !== 'undefined' && process.env && process.env.NODE_ENV === 'test';
+
 export function payMaintenanceCosts() {
   for (const prop of game.properties) {
     if (!prop.maintenanceCost) continue;
@@ -14,7 +17,7 @@ export function payMaintenanceCosts() {
       ],
       'property'
     );
-    if (process.env.NODE_ENV !== 'test') {
+    if (!testing) {
       if (rand(1, 100) <= taskChances.property.suddenExpense) {
         const extra = Math.round(prop.maintenanceCost * rand(1, 3));
         game.money -= extra;


### PR DESCRIPTION
## Summary
- Avoid ReferenceError by checking for `process` in age up random events
- Prevent property maintenance from touching `process` in browsers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be1603b954832aac45ef1494a79ee7