### PR TITLE
Remove blur slider and reset default blur

### DIFF
--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -9,45 +9,19 @@ export function setTheme(theme) {
   localStorage.setItem('theme', theme);
 }
 
-let transparencySlider;
-
 export function setWindowTransparency(solid) {
-  const stored = parseFloat(localStorage.getItem('windowBlur')) || 2;
-  document.documentElement.style.setProperty('--window-blur', `${stored}px`);
+  localStorage.removeItem('windowBlur');
+  document.documentElement.style.setProperty('--window-blur', '2px');
   const transparencyToggle = document.getElementById('transparencyToggle');
   document.body.classList.toggle('solid-windows', solid);
   if (transparencyToggle) {
     transparencyToggle.textContent = solid ? '⬛' : '🔲';
     transparencyToggle.setAttribute('aria-pressed', String(solid));
     if (!solid) {
-      if (!transparencySlider) {
-        transparencySlider = document.createElement('input');
-        transparencySlider.type = 'range';
-        transparencySlider.min = '0';
-        transparencySlider.max = '10';
-        transparencySlider.step = '0.5';
-        transparencySlider.style.marginLeft = '8px';
-        transparencySlider.setAttribute('aria-label', 'Adjust background blur');
-        transparencySlider.title = 'Adjust background blur';
-        transparencySlider.value = String(stored);
-        transparencySlider.addEventListener('input', e => {
-          const value = e.target.value;
-          document.documentElement.style.setProperty('--window-blur', `${value}px`);
-          localStorage.setItem('windowBlur', value);
-        });
-      }
-      transparencyToggle.after(transparencySlider);
       document.documentElement.style.removeProperty('--window-opacity');
     } else {
       document.documentElement.style.setProperty('--window-opacity', '1');
-      if (transparencySlider) {
-        transparencySlider.remove();
-      }
     }
-  }
-  if (!solid) {
-    const value = transparencySlider ? transparencySlider.value : String(stored);
-    localStorage.setItem('windowBlur', value);
   }
   localStorage.setItem('solidWindows', solid ? '1' : '0');
 }


### PR DESCRIPTION
## Summary
- Remove background blur slider logic
- Always use default 2px blur and store only transparency state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be16513a3c832ab07d1fca7cbdb592