### PR TITLE
Add achievement progress summary and filtering

### DIFF
--- a/scripts/renderers/achievements.js
+++ b/scripts/renderers/achievements.js
@@ -1,14 +1,38 @@
 import { game, ACHIEVEMENTS } from '../state.js';
 
 export function renderAchievements(container) {
+  const total = Object.keys(ACHIEVEMENTS).length;
+  let unlockedCount = 0;
+
   const list = document.createElement('div');
   list.className = 'achievements';
   for (const [id, text] of Object.entries(ACHIEVEMENTS)) {
     const unlocked = game.achievements.some(a => a.id === id);
+    if (unlocked) unlockedCount++;
     const e = document.createElement('div');
-    e.className = 'entry';
-    e.textContent = unlocked ? text : `${text} (locked)`;
+    e.className = `entry ${unlocked ? 'unlocked' : 'locked'}`;
+    e.textContent = text;
     list.appendChild(e);
   }
+
+  const summary = document.createElement('div');
+  summary.className = 'summary';
+  summary.textContent = `${unlockedCount}/${total} achievements unlocked`;
+
+  const filterLabel = document.createElement('label');
+  filterLabel.className = 'filter';
+  const filter = document.createElement('input');
+  filter.type = 'checkbox';
+  filterLabel.appendChild(filter);
+  filterLabel.appendChild(document.createTextNode(' Show unlocked only'));
+
+  filter.addEventListener('change', () => {
+    list.querySelectorAll('.entry.locked').forEach(el => {
+      el.style.display = filter.checked ? 'none' : '';
+    });
+  });
+
+  container.appendChild(summary);
+  container.appendChild(filterLabel);
   container.appendChild(list);
 }

--- a/styles/components.css
+++ b/styles/components.css
@@ -119,6 +119,12 @@ body.solid-windows .window .content{
 .log .entry{ padding: 6px 8px; border-radius: 8px; border:1px solid var(--stroke); background: rgba(255,255,255,.04); margin: 6px 0; }
 .log time{ color: var(--muted); font-size: .85rem; }
 
+.achievements .summary{ font-weight: 700; margin-bottom: 8px; }
+.achievements .filter{ display:flex; align-items:center; gap:4px; margin-bottom:8px; }
+.achievements .entry{ padding:6px 8px; border:1px solid var(--stroke); border-radius:8px; margin:6px 0; }
+.achievements .entry.unlocked{ border-color: var(--good); }
+.achievements .entry.locked{ opacity:.5; }
+
 .badge{ display:inline-block; padding: 2px 8px; border-radius: 999px; border:1px solid var(--stroke); background: rgba(255,255,255,.06); font-size:.8rem; color: var(--muted); }
 .badge.boom{ background: var(--good); color: var(--surface); }
 .badge.recession{ background: var(--bad); color: var(--surface); }

--- a/tests/renderers.achievements.test.js
+++ b/tests/renderers.achievements.test.js
@@ -1,0 +1,29 @@
+/** @jest-environment jsdom */
+import { game, ACHIEVEMENTS } from '../scripts/state.js';
+import { renderAchievements } from '../scripts/renderers/achievements.js';
+
+describe('renderAchievements', () => {
+  beforeEach(() => {
+    game.achievements = [{ id: 'first-job', text: ACHIEVEMENTS['first-job'] }];
+  });
+
+  test('shows summary and entry states', () => {
+    const container = document.createElement('div');
+    renderAchievements(container);
+    const summary = container.querySelector('.summary');
+    expect(summary.textContent).toBe('1/5 achievements unlocked');
+    expect(container.querySelectorAll('.entry.unlocked')).toHaveLength(1);
+    const lockedCount = Object.keys(ACHIEVEMENTS).length - 1;
+    expect(container.querySelectorAll('.entry.locked')).toHaveLength(lockedCount);
+  });
+
+  test('filters locked achievements', () => {
+    const container = document.createElement('div');
+    renderAchievements(container);
+    const toggle = container.querySelector('.filter input');
+    toggle.checked = true;
+    toggle.dispatchEvent(new Event('change'));
+    const hidden = Array.from(container.querySelectorAll('.entry.locked')).every(el => el.style.display === 'none');
+    expect(hidden).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- show unlocked/total achievement progress
- style locked achievements and allow filtering
- cover achievements renderer with tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68beff00bf20832a875599d064a6b0e2