### PR TITLE
feat: add life summary screen

### DIFF
--- a/scripts/endscreen.js
+++ b/scripts/endscreen.js
@@ -36,9 +36,68 @@ function generateStory(game) {
 
 export function showEndScreen(game) {
   screenEl.textContent = '';
+  const summary = document.createElement('div');
+  summary.className = 'summary';
   const title = document.createElement('h2');
-  title.textContent = 'Life Story';
-  screenEl.appendChild(title);
+  title.textContent = 'Life Summary';
+  summary.appendChild(title);
+  const stats = document.createElement('ul');
+  const items = [
+    ['Age', game.age],
+    ['Money', `$${game.money.toLocaleString()}`],
+    [
+      'Achievements',
+      game.achievements.length
+        ? game.achievements.map(a => a.text).join(', ')
+        : 'None'
+    ],
+    [
+      'Properties',
+      game.properties.length
+        ? game.properties.map(p => p.name).join(', ')
+        : 'None'
+    ]
+  ];
+  for (const [label, value] of items) {
+    const li = document.createElement('li');
+    li.innerHTML = `<strong>${label}:</strong> ${value}`;
+    stats.appendChild(li);
+  }
+  summary.appendChild(stats);
+  const actions = document.createElement('div');
+  actions.className = 'actions';
+  const exportBtn = document.createElement('button');
+  exportBtn.textContent = 'Export Summary';
+  exportBtn.addEventListener('click', () => {
+    const data = {
+      age: game.age,
+      money: game.money,
+      achievements: game.achievements.map(a => a.text),
+      properties: game.properties.map(p => p.name)
+    };
+    const blob = new Blob([JSON.stringify(data, null, 2)], {
+      type: 'application/json'
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'life-summary.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  });
+  actions.appendChild(exportBtn);
+  const restart = document.createElement('button');
+  restart.textContent = 'Start new life';
+  restart.addEventListener('click', () => {
+    hideEndScreen();
+    openWindow('newLife', 'New Life', renderNewLife);
+  });
+  actions.appendChild(restart);
+  summary.appendChild(actions);
+  screenEl.appendChild(summary);
+  const storyTitle = document.createElement('h2');
+  storyTitle.textContent = 'Life Story';
+  screenEl.appendChild(storyTitle);
   const story = document.createElement('p');
   story.textContent = generateStory(game);
   screenEl.appendChild(story);
@@ -53,13 +112,6 @@ export function showEndScreen(game) {
     list.appendChild(li);
   }
   screenEl.appendChild(list);
-  const restart = document.createElement('button');
-  restart.textContent = 'Start new life';
-  restart.addEventListener('click', () => {
-    hideEndScreen();
-    openWindow('newLife', 'New Life', renderNewLife);
-  });
-  screenEl.appendChild(restart);
   screenEl.classList.remove('hidden');
 }
 

--- a/scripts/state.js
+++ b/scripts/state.js
@@ -159,6 +159,17 @@ export const game = {
 
 let currentSlot = storageAvailable() ? localStorage.getItem('currentSlot') : null;
 
+const originalTransition = lifeState.transition.bind(lifeState);
+lifeState.transition = function (event) {
+  const result = originalTransition(event);
+  if (result && this.state === 'dead') {
+    showEndScreen(game);
+  } else if (result && this.state === 'alive') {
+    hideEndScreen();
+  }
+  return result;
+};
+
 function getSlots() {
   if (!storageAvailable()) return [];
   try {
@@ -254,7 +265,6 @@ export function die(reason) {
     openWindow('newLife', 'New Life', renderNewLife);
   });
   setDockButtonsDisabled(true);
-  showEndScreen(game);
 }
 
 /**
@@ -397,7 +407,6 @@ export function newLife(genderInput, nameInput, options = {}) {
   lifeState.transition(lifeState.state === 'initial' ? 'start' : 'restart');
   const currentYear = new Date().getFullYear();
   const startYear = options.startYear ?? rand(1900, currentYear);
-  hideEndScreen();
   setDockButtonsDisabled(false);
   if (currentSlot) {
     localStorage.removeItem(`gameState_${currentSlot}`);

--- a/styles/components.css
+++ b/styles/components.css
@@ -144,6 +144,11 @@ body.solid-windows .window .content{
   align-self: center;
   margin-top: auto;
 }
+#endscreen .summary{ max-width: 600px; margin: 0 auto; text-align: center; }
+#endscreen .summary ul{ list-style: none; padding: 0; margin: 0 0 20px; }
+#endscreen .summary li{ margin: 4px 0; }
+#endscreen .actions{ display: flex; gap: 10px; justify-content: center; }
+#endscreen .actions button{ margin-top: 0; align-self: auto; }
 
 @media (max-width: 640px){
   .window{ width: 86vw; min-width: auto; }


### PR DESCRIPTION
## Summary
- compile end-of-life statistics and export option
- show summary automatically when life state becomes dead
- style summary layout and actions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68beff387bd8832aa8a7d3a176ec5185