### PR TITLE
Add accessible labels for icon buttons

### DIFF
--- a/partials/dock.html
+++ b/partials/dock.html
@@ -13,7 +13,13 @@
   <button data-toggle="help" role="button" aria-label="Open Help window">Help</button>
   <button data-toggle="newLife" role="button" aria-label="Start a new life">New Life</button>
   <button id="closeAll" role="button" aria-label="Close all windows">Close All</button>
-  <button id="transparencyToggle" title="Toggle window transparency" style="margin-left:auto" role="button" aria-label="Toggle window transparency" aria-pressed="false">🔲</button>
-  <button id="themeToggle" title="Toggle theme" role="button" aria-label="Toggle theme" aria-pressed="false">🌙</button>
+  <button id="transparencyToggle" title="Toggle window transparency" style="margin-left:auto" role="button" aria-pressed="false" aria-label="Toggle window transparency">
+    <span class="visually-hidden">Toggle window transparency</span>
+    <span class="icon" aria-hidden="true">🔲</span>
+  </button>
+  <button id="themeToggle" title="Toggle theme" role="button" aria-pressed="false" aria-label="Toggle theme">
+    <span class="visually-hidden">Toggle theme</span>
+    <span class="icon" aria-hidden="true">🌙</span>
+  </button>
 </div>
 

--- a/partials/window-template.html
+++ b/partials/window-template.html
@@ -2,7 +2,10 @@
   <div class="titlebar" role="toolbar" aria-label="Window controls" aria-grabbed="false">
     <span class="title">Window</span>
     <div class="controls">
-      <div class="control-btn btn-close" role="button" title="Close" aria-label="Close">✕</div>
+      <div class="control-btn btn-close" role="button" title="Close" aria-label="Close">
+        <span class="visually-hidden">Close window</span>
+        <span class="icon" aria-hidden="true">✕</span>
+      </div>
     </div>
   </div>
   <div class="content"></div>

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -3,8 +3,14 @@ export function setTheme(theme) {
   const isDark = theme === 'dark';
   document.body.classList.toggle('dark', isDark);
   if (themeToggle) {
-    themeToggle.textContent = isDark ? '☀️' : '🌙';
+    const label = isDark ? 'Switch to light theme' : 'Switch to dark theme';
+    const icon = isDark ? '☀️' : '🌙';
     themeToggle.setAttribute('aria-pressed', String(isDark));
+    themeToggle.setAttribute('aria-label', label);
+    const srSpan = themeToggle.querySelector('.visually-hidden');
+    if (srSpan) srSpan.textContent = label;
+    const iconSpan = themeToggle.querySelector('.icon');
+    if (iconSpan) iconSpan.textContent = icon;
   }
   localStorage.setItem('theme', theme);
 }
@@ -15,8 +21,14 @@ export function setWindowTransparency(solid) {
   const transparencyToggle = document.getElementById('transparencyToggle');
   document.body.classList.toggle('solid-windows', solid);
   if (transparencyToggle) {
-    transparencyToggle.textContent = solid ? '⬛' : '🔲';
+    const label = solid ? 'Disable window transparency' : 'Enable window transparency';
+    const icon = solid ? '⬛' : '🔲';
     transparencyToggle.setAttribute('aria-pressed', String(solid));
+    transparencyToggle.setAttribute('aria-label', label);
+    const srSpan = transparencyToggle.querySelector('.visually-hidden');
+    if (srSpan) srSpan.textContent = label;
+    const iconSpan = transparencyToggle.querySelector('.icon');
+    if (iconSpan) iconSpan.textContent = icon;
     if (!solid) {
       document.documentElement.style.removeProperty('--window-opacity');
     } else {

--- a/styles/base.css
+++ b/styles/base.css
@@ -55,3 +55,15 @@ body:not(:hover) *::-webkit-scrollbar{
   width: 0;
   height: 0;
 }
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}


### PR DESCRIPTION
## Summary
- Add visually hidden utility class for screen-reader-only text
- Provide text labels and hidden spans for icon-only dock and window buttons
- Update theme and transparency toggles to dynamically refresh aria-labels and hidden text

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68beff2f3da4832a8a952e38016a397c