### PR TITLE
Add matching donation chance to charity activity

### DIFF
--- a/scripts/activities/charity.js
+++ b/scripts/activities/charity.js
@@ -39,15 +39,20 @@ export function renderCharity(container) {
     }
     applyAndSave(() => {
       game.money -= amt;
-      const gain = Math.max(1, Math.floor(amt / 100));
+      let donated = amt;
+      if (rand(1, 100) <= taskChances.charity.matchingDonation) {
+        donated *= 2;
+        addLog('A sponsor matched your donation!', 'charity');
+      }
+      const gain = Math.max(1, Math.floor(donated / 100));
       game.reputation = clamp(game.reputation + gain);
       if (rand(1, 100) <= taskChances.charity.publicity) {
         game.reputation = clamp(game.reputation + 5);
         addLog('Your donation made headlines! +5 Reputation.', 'charity');
       }
-      game.charityTotal += amt;
-      game.charityYear += amt;
-      addLog(`You donated $${amt}. +${gain} Reputation.`, 'charity');
+      game.charityTotal += donated;
+      game.charityYear += donated;
+      addLog(`You donated $${donated}. +${gain} Reputation.`, 'charity');
       total.textContent = `Total Donated: $${game.charityTotal}`;
     });
   });

--- a/scripts/taskChances.js
+++ b/scripts/taskChances.js
@@ -167,7 +167,8 @@ export const taskChances = {
 
   // Charitable efforts
   charity: {
-    publicity: 20 // Chance donation gains public recognition
+    publicity: 20, // Chance donation gains public recognition
+    matchingDonation: 15 // Chance donation is matched by a sponsor
   },
 
   // Fertility treatments

--- a/tests/activities.charity.test.js
+++ b/tests/activities.charity.test.js
@@ -1,0 +1,43 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from '@jest/globals';
+
+const game = { money: 500, reputation: 50, charityTotal: 0, charityYear: 0, log: [] };
+const addLog = jest.fn((text, category = 'general') => {
+  game.log.unshift({ text, category });
+});
+const applyAndSave = fn => fn();
+const rand = jest.fn();
+
+await jest.unstable_mockModule('../scripts/utils.js', () => ({
+  rand,
+  clamp: v => v
+}));
+await jest.unstable_mockModule('../scripts/state.js', () => ({
+  game,
+  addLog,
+  applyAndSave,
+  saveGame: jest.fn()
+}));
+await jest.unstable_mockModule('../scripts/taskChances.js', () => ({
+  taskChances: { charity: { matchingDonation: 100, publicity: 0 } }
+}));
+
+const { renderCharity } = await import('../scripts/activities/charity.js');
+
+test('matching donation doubles amount and logs message', () => {
+  rand.mockReturnValueOnce(1).mockReturnValueOnce(100);
+  const container = document.createElement('div');
+  renderCharity(container);
+  const input = container.querySelector('input');
+  const btn = container.querySelector('button');
+  input.value = '100';
+  btn.click();
+  expect(game.charityTotal).toBe(200);
+  expect(game.charityYear).toBe(200);
+  expect(game.reputation).toBe(52);
+  expect(addLog).toHaveBeenCalledWith('A sponsor matched your donation!', 'charity');
+  expect(addLog).toHaveBeenCalledWith('You donated $200. +2 Reputation.', 'charity');
+});


### PR DESCRIPTION
## Summary
- add configurable matchingDonation chance for charity
- double donation when matched and log special message
- test matching donation behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68beff1f3278832ab5bbe910fc6b385d