### PR TITLE
feat: add storage fallback and warning

### DIFF
--- a/scripts/activities/lottery.js
+++ b/scripts/activities/lottery.js
@@ -1,9 +1,6 @@
 import { game, addLog, applyAndSave } from '../state.js';
 import { clamp } from '../utils.js';
-import { openWindow } from '../windowManager.js';
 import { taskChances } from '../taskChances.js';
-
-export { openWindow };
 
 function renderStandardLottery(container) {
   const wrap = document.createElement('div');

--- a/scripts/renderers/stats.js
+++ b/scripts/renderers/stats.js
@@ -1,8 +1,14 @@
-import { game } from '../state.js';
+import { game, hasPersistence } from '../state.js';
 import { clamp } from '../utils.js';
 import { eduName } from '../school.js';
 
 export function renderStats(container) {
+  if (!hasPersistence) {
+    const warn = document.createElement('div');
+    warn.className = 'warning-banner';
+    warn.textContent = '⚠️ Progress will reset when the page reloads.';
+    container.appendChild(warn);
+  }
   const makeKpi = (label, val, title = '') => {
     const pct = clamp(val);
     const div = document.createElement('div');

--- a/scripts/script.js
+++ b/scripts/script.js
@@ -1,5 +1,5 @@
 import { initWindowManager, openWindow, toggleWindow, registerWindow, restoreOpenWindows, closeAllWindows, getRegisteredWindows } from './windowManager.js';
-import { newLife, loadGame, addLog, getCurrentSlot, listSlots } from './state.js';
+import { newLife, loadGame, addLog, getCurrentSlot, listSlots, storageGetItem } from './state.js';
 import { renderStats } from './renderers/stats.js';
 import { renderActions } from './renderers/actions.js';
 import { renderLog } from './renderers/log.js';
@@ -75,13 +75,13 @@ if (dock) {
 }
 
 
-let theme = localStorage.getItem('theme');
+let theme = storageGetItem('theme');
 if (!theme) {
   theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 }
 setTheme(theme);
 
-let solid = localStorage.getItem('solidWindows') === '1';
+let solid = storageGetItem('solidWindows') === '1';
 setWindowTransparency(solid);
 
 if (transparencyToggle) {

--- a/scripts/state.js
+++ b/scripts/state.js
@@ -51,6 +51,36 @@ export function storageAvailable() {
   }
 }
 
+const memoryStorage = (() => {
+  const store = {};
+  return {
+    getItem(key) {
+      return key in store ? store[key] : null;
+    },
+    setItem(key, value) {
+      store[key] = String(value);
+    },
+    removeItem(key) {
+      delete store[key];
+    }
+  };
+})();
+
+export const hasPersistence = storageAvailable();
+export const storage = hasPersistence ? localStorage : memoryStorage;
+
+export function storageGetItem(key) {
+  return storage.getItem(key);
+}
+
+export function storageSetItem(key, value) {
+  storage.setItem(key, value);
+}
+
+export function storageRemoveItem(key) {
+  storage.removeItem(key);
+}
+
 function setDockButtonsDisabled(disabled) {
   if (typeof document === 'undefined') return;
   document.querySelectorAll('.dock button').forEach(btn => {
@@ -157,12 +187,11 @@ export const game = {
   log: []
 };
 
-let currentSlot = storageAvailable() ? localStorage.getItem('currentSlot') : null;
+let currentSlot = storageGetItem('currentSlot');
 
 function getSlots() {
-  if (!storageAvailable()) return [];
   try {
-    const slots = JSON.parse(localStorage.getItem('saveSlots') || '[]');
+    const slots = JSON.parse(storageGetItem('saveSlots') || '[]');
     return Array.isArray(slots) ? slots : [];
   } catch {
     return [];
@@ -170,9 +199,7 @@ function getSlots() {
 }
 
 function setSlots(slots) {
-  if (storageAvailable()) {
-    localStorage.setItem('saveSlots', JSON.stringify(slots));
-  }
+  storageSetItem('saveSlots', JSON.stringify(slots));
 }
 
 export function listSlots() {
@@ -184,19 +211,17 @@ export function getCurrentSlot() {
 }
 
 export function setCurrentSlot(name) {
-  if (!storageAvailable()) return;
   currentSlot = name;
-  localStorage.setItem('currentSlot', name);
+  storageSetItem('currentSlot', name);
 }
 
 export function deleteSlot(name) {
-  if (!storageAvailable()) return;
-  localStorage.removeItem(`gameState_${name}`);
+  storageRemoveItem(`gameState_${name}`);
   const slots = getSlots().filter(s => s !== name);
   setSlots(slots);
   if (currentSlot === name) {
     currentSlot = null;
-    localStorage.removeItem('currentSlot');
+    storageRemoveItem('currentSlot');
   }
 }
 
@@ -262,10 +287,6 @@ export function die(reason) {
  * @returns {void}
  */
 export function saveGame() {
-  if (!storageAvailable()) {
-    console.warn('Local storage is unavailable; cannot save game.');
-    return;
-  }
   if (!currentSlot) {
     const existing = getSlots();
     let idx = 1;
@@ -281,7 +302,7 @@ export function saveGame() {
     slots.push(currentSlot);
     setSlots(slots);
   }
-  localStorage.setItem(`gameState_${currentSlot}`, JSON.stringify(game));
+  storageSetItem(`gameState_${currentSlot}`, JSON.stringify(game));
 }
 
 /**
@@ -302,12 +323,8 @@ export function updateAthleticPerformance() {
 }
 
 export function loadGame(slot = currentSlot) {
-  if (!storageAvailable()) {
-    console.warn('Local storage is unavailable; cannot load game.');
-    return false;
-  }
   if (!slot) return false;
-  const data = localStorage.getItem(`gameState_${slot}`);
+  const data = storageGetItem(`gameState_${slot}`);
   if (!data) return false;
   try {
     Object.assign(game, JSON.parse(data));
@@ -378,7 +395,7 @@ export function loadGame(slot = currentSlot) {
       game.spouse = null;
     }
   } catch {
-    localStorage.removeItem(`gameState_${slot}`);
+    storageRemoveItem(`gameState_${slot}`);
     deleteSlot(slot);
     return false;
   }
@@ -400,7 +417,7 @@ export function newLife(genderInput, nameInput, options = {}) {
   hideEndScreen();
   setDockButtonsDisabled(false);
   if (currentSlot) {
-    localStorage.removeItem(`gameState_${currentSlot}`);
+    storageRemoveItem(`gameState_${currentSlot}`);
   } else {
     const slots = listSlots();
     let idx = 1;

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -1,3 +1,5 @@
+import { storageSetItem, storageRemoveItem } from './state.js';
+
 export function setTheme(theme) {
   const themeToggle = document.getElementById('themeToggle');
   const isDark = theme === 'dark';
@@ -6,11 +8,11 @@ export function setTheme(theme) {
     themeToggle.textContent = isDark ? '☀️' : '🌙';
     themeToggle.setAttribute('aria-pressed', String(isDark));
   }
-  localStorage.setItem('theme', theme);
+  storageSetItem('theme', theme);
 }
 
 export function setWindowTransparency(solid) {
-  localStorage.removeItem('windowBlur');
+  storageRemoveItem('windowBlur');
   document.documentElement.style.setProperty('--window-blur', '2px');
   const transparencyToggle = document.getElementById('transparencyToggle');
   document.body.classList.toggle('solid-windows', solid);
@@ -23,6 +25,6 @@ export function setWindowTransparency(solid) {
       document.documentElement.style.setProperty('--window-opacity', '1');
     }
   }
-  localStorage.setItem('solidWindows', solid ? '1' : '0');
+  storageSetItem('solidWindows', solid ? '1' : '0');
 }
 

--- a/scripts/windowManager.js
+++ b/scripts/windowManager.js
@@ -1,3 +1,5 @@
+import { storageGetItem, storageSetItem, storageRemoveItem } from './state.js';
+
 let desktop;
 let template;
 let zCounter = 10;
@@ -14,15 +16,15 @@ function persistOpenWindows() {
     .filter(w => !w.classList.contains('hidden'))
     .map(w => w.dataset.id);
   if (ids.length) {
-    localStorage.setItem(OPEN_WINDOWS_KEY, JSON.stringify(ids));
+    storageSetItem(OPEN_WINDOWS_KEY, JSON.stringify(ids));
   } else {
-    localStorage.removeItem(OPEN_WINDOWS_KEY);
+    storageRemoveItem(OPEN_WINDOWS_KEY);
   }
 }
 
 function savePosition(win) {
   const id = win.dataset.id;
-  localStorage.setItem(`window-pos-${id}`, JSON.stringify({
+  storageSetItem(`window-pos-${id}`, JSON.stringify({
     left: win.style.left,
     top: win.style.top,
     width: win.style.width || win.offsetWidth + 'px',
@@ -57,7 +59,7 @@ function scaleToViewport(win) {
 
 function adjustWindowPositions() {
   document.querySelectorAll('.window:not(.hidden)').forEach(win => {
-    const stored = localStorage.getItem(`window-pos-${win.dataset.id}`);
+    const stored = storageGetItem(`window-pos-${win.dataset.id}`);
     if (stored) {
       const pos = JSON.parse(stored);
       win.style.left = pos.left;
@@ -71,7 +73,7 @@ function adjustWindowPositions() {
 }
 
 function restorePosition(win, index) {
-  const stored = localStorage.getItem(`window-pos-${win.dataset.id}`);
+  const stored = storageGetItem(`window-pos-${win.dataset.id}`);
   if (stored) {
     const pos = JSON.parse(stored);
     win.style.left = pos.left;
@@ -400,7 +402,7 @@ export function closeWindow(id) {
  * @returns {void}
  */
 export function restoreOpenWindows() {
-  const stored = localStorage.getItem(OPEN_WINDOWS_KEY);
+  const stored = storageGetItem(OPEN_WINDOWS_KEY);
   if (!stored) return;
   const ids = JSON.parse(stored);
   ids.forEach(id => {

--- a/styles/components.css
+++ b/styles/components.css
@@ -82,6 +82,8 @@ body.solid-windows .window .content{
 .actions .btn:hover{ border-color: rgba(255,255,255,.35); }
 .muted{ color: var(--muted); font-size: .92rem; }
 
+.warning-banner{ background: var(--warn); color: var(--surface); padding: 6px 8px; border-radius: 8px; text-align:center; margin-bottom:8px; }
+
 .jobs .job{ padding:10px 10px; border:1px solid var(--stroke); border-radius: 10px; margin:8px 0; display:flex; justify-content:space-between; align-items:center; cursor:pointer; }
 .jobs .job:hover{ border-color: rgba(255,255,255,.35); }
 


### PR DESCRIPTION
## Summary
- add memory-backed storage helpers to replace direct localStorage access
- show a banner when persistence isn't available
- switch UI and window manager modules to use storage helpers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68beff10de8c832a876cd99205038e9f