### PR TITLE
feat: add family planning and child aging

### DIFF
--- a/scripts/actions/ageUp.js
+++ b/scripts/actions/ageUp.js
@@ -518,8 +518,9 @@ export function ageUp() {
         game.businesses.splice(i, 1);
       }
     }
-    if (game.children && game.children.length > 0) {
-      for (const child of game.children) {
+    const kids = game.state.children;
+    if (kids && kids.length > 0) {
+      for (const child of kids) {
         child.age += 1;
         child.happiness = clamp(child.happiness + rand(-2, 2));
         if (child.age === 18) {

--- a/scripts/actions/family.js
+++ b/scripts/actions/family.js
@@ -70,10 +70,10 @@ export function haveChild() {
   }
   applyAndSave(() => {
     const child = { age: 0, happiness: 50 };
-    if (!game.children) game.children = [];
-    game.children.push(child);
+    if (!game.state.children) game.state.children = [];
+    game.state.children.push(child);
     if (rand(1, 100) <= taskChances.family.twins) {
-      game.children.push({ age: 0, happiness: 50 });
+      game.state.children.push({ age: 0, happiness: 50 });
       addLog(
         [
           'You welcomed twins into the world.',
@@ -89,15 +89,15 @@ export function haveChild() {
         'You became a parent to a newborn.'
       ], 'family');
     }
-    if (game.children.length === 1) {
+    if (game.state.children.length === 1) {
       unlockAchievement('first-child', FIRST_CHILD_DESC);
     }
   });
 }
 
 export function spendTimeWithChild(index = 0) {
-  if (!game.alive || !game.children || !game.children[index]) return;
-  const child = game.children[index];
+  if (!game.alive || !game.state.children || !game.state.children[index]) return;
+  const child = game.state.children[index];
   const childChance = combineChance(
     taskChances.family.childTime,
     child.happiness,

--- a/scripts/activities/adoption.js
+++ b/scripts/activities/adoption.js
@@ -37,8 +37,8 @@ export function renderAdoption(container) {
         if (roll <= chance) {
           const name = faker.person.firstName();
           const child = { name, age: opt.age, happiness: opt.happiness };
-          if (!game.children) game.children = [];
-          game.children.push(child);
+          if (!game.state.children) game.state.children = [];
+          game.state.children.push(child);
           addLog(
             [
               `You adopted ${name}.`,

--- a/scripts/activities/daycare.js
+++ b/scripts/activities/daycare.js
@@ -5,10 +5,10 @@ import { taskChances } from '../taskChances.js';
 const WEEKLY_FEE_PER_CHILD = 200;
 
 export function renderDaycare(container) {
-  game.children = game.children || [];
+  game.state.children = game.state.children || [];
   const wrap = document.createElement('div');
 
-  const cost = WEEKLY_FEE_PER_CHILD * game.children.length;
+  const cost = WEEKLY_FEE_PER_CHILD * game.state.children.length;
 
   const btn = document.createElement('button');
   btn.className = 'btn block';

--- a/scripts/activities/familyPlanning.js
+++ b/scripts/activities/familyPlanning.js
@@ -1,0 +1,72 @@
+import { game, addLog, applyAndSave } from '../state.js';
+import { taskChances } from '../taskChances.js';
+import { rand, clamp } from '../utils.js';
+import { getFaker } from '../utils/faker.js';
+
+const faker = await getFaker();
+
+export function renderFamilyPlanning(container) {
+  const wrap = document.createElement('div');
+
+  const conceiveBtn = document.createElement('button');
+  conceiveBtn.className = 'btn block';
+  conceiveBtn.textContent = `Try to Conceive (${taskChances.familyPlanning.conception}% chance)`;
+  conceiveBtn.addEventListener('click', () => {
+    applyAndSave(() => {
+      if (rand(1, 100) <= taskChances.familyPlanning.conception) {
+        const name = faker.person.firstName();
+        const child = { name, age: 0, happiness: 50, smarts: 50 };
+        game.state.children.push(child);
+        addLog(`You welcomed ${name} to the family.`, 'family');
+        renderChildren();
+      } else {
+        addLog('Conception attempt failed.', 'family');
+      }
+    });
+  });
+  wrap.appendChild(conceiveBtn);
+
+  const list = document.createElement('div');
+  wrap.appendChild(list);
+
+  function careForChild(index) {
+    applyAndSave(() => {
+      const child = game.state.children[index];
+      if (rand(1, 100) <= taskChances.familyPlanning.care) {
+        child.happiness = clamp(child.happiness + rand(5, 15));
+        child.smarts = clamp(child.smarts + rand(1, 5));
+        addLog(`You cared for ${child.name}. (+Happiness, +Smarts)`, 'family');
+      } else {
+        addLog(`${child.name} resisted your care.`, 'family');
+      }
+    });
+    renderChildren();
+  }
+
+  function renderChildren() {
+    list.innerHTML = '';
+    const kids = game.state.children;
+    if (!kids.length) {
+      const note = document.createElement('div');
+      note.className = 'muted';
+      note.textContent = 'No children yet.';
+      list.appendChild(note);
+      return;
+    }
+    kids.forEach((child, i) => {
+      const childDiv = document.createElement('div');
+      childDiv.className = 'child';
+      childDiv.textContent = `${child.name} - Age ${child.age} | Happiness ${child.happiness} | Smarts ${child.smarts}`;
+      const careBtn = document.createElement('button');
+      careBtn.className = 'btn block';
+      careBtn.textContent = `Care for ${child.name}`;
+      careBtn.addEventListener('click', () => careForChild(i));
+      childDiv.appendChild(careBtn);
+      list.appendChild(childDiv);
+    });
+  }
+
+  renderChildren();
+  container.appendChild(wrap);
+}
+

--- a/scripts/activities/fertility.js
+++ b/scripts/activities/fertility.js
@@ -28,8 +28,8 @@ export function renderFertility(container) {
         if (rand(1, 100) <= taskChances.fertility[t.key]) {
           const name = faker.person.firstName();
           const child = { name, age: 0, happiness: 90 };
-          if (!game.children) game.children = [];
-          game.children.push(child);
+          if (!game.state.children) game.state.children = [];
+          game.state.children.push(child);
           addLog(`Fertility treatment succeeded! You welcomed ${name}.`, 'family');
         } else {
           addLog('Fertility treatment failed.', 'family');

--- a/scripts/activities/willAndTestament.js
+++ b/scripts/activities/willAndTestament.js
@@ -36,12 +36,12 @@ export function renderWillAndTestament(container) {
           return;
         }
         applyAndSave(() => {
-          if (!game.children || game.children.length === 0) {
+          if (!game.state.children || game.state.children.length === 0) {
             addLog('You have no children to inherit your estate.', 'property');
           } else {
-            const share = 1 / game.children.length;
+            const share = 1 / game.state.children.length;
             game.inheritance = {};
-            for (const child of game.children) {
+            for (const child of game.state.children) {
               game.inheritance[child.name] = share;
             }
             addLog('You updated your will to divide your estate among your children.', 'property');

--- a/scripts/renderers/activities.js
+++ b/scripts/renderers/activities.js
@@ -35,6 +35,7 @@ const ACTIVITIES_CATEGORIES = {
     'Adoption',
     'Daycare',
     'Fertility',
+    'Family Planning',
     'Love',
     'Volunteer Shelter',
     'Pets',
@@ -101,6 +102,7 @@ const ACTIVITY_ICONS = {
   Adoption: '👶',
   Daycare: '🧸',
   Fertility: '🧬',
+  'Family Planning': '🍼',
   Love: '❤️',
   'Volunteer Shelter': '🤝',
   Pets: '🐾',
@@ -158,6 +160,12 @@ const ACTIVITY_RENDERERS = {
   Adoption: () => openActivity('adoption', 'Adoption', '../activities/adoption.js', 'renderAdoption'),
   Daycare: () => openActivity('daycare', 'Daycare', '../activities/daycare.js', 'renderDaycare'),
   Fertility: () => openActivity('fertility', 'Fertility', '../activities/fertility.js', 'renderFertility'),
+  'Family Planning': () => openActivity(
+    'familyPlanning',
+    'Family Planning',
+    '../activities/familyPlanning.js',
+    'renderFamilyPlanning'
+  ),
   'Elder Care': () => openActivity('elderCare', 'Elder Care', '../activities/elderCare.js', 'renderElderCare'),
   Siblings: () => openActivity('siblings', 'Siblings', '../activities/siblings.js', 'renderSiblings'),
   Lottery: () => openActivity('lottery', 'Lottery', '../activities/lottery.js', 'renderLottery'),
@@ -231,7 +239,7 @@ export function renderActivities(container) {
 
     for (const item of items) {
       if (
-        (item === 'Daycare' && (!game.job || !game.children || game.children.length === 0)) ||
+        (item === 'Daycare' && (!game.job || !game.state.children || game.state.children.length === 0)) ||
         (item === 'Siblings' && (!game.siblings || game.siblings.length === 0))
       ) {
         continue;

--- a/scripts/renderers/character.js
+++ b/scripts/renderers/character.js
@@ -4,9 +4,9 @@ export function renderCharacter(container) {
   const div = document.createElement('div');
   div.className = 'grid';
   let childrenHTML = '';
-  if (game.children && game.children.length > 0) {
+  if (game.state.children && game.state.children.length > 0) {
     childrenHTML = '<div class="row"><strong>Children:</strong><ul>';
-    for (const [i, child] of game.children.entries()) {
+    for (const [i, child] of game.state.children.entries()) {
       const name = child.name ? child.name : `Child ${i + 1}`;
       childrenHTML += `<li>${name} - Age ${child.age}, Happiness ${child.happiness}</li>`;
     }

--- a/scripts/renderers/newlife.js
+++ b/scripts/renderers/newlife.js
@@ -74,12 +74,12 @@ export function renderSlotManager(container) {
 }
 
 export function renderNewLife(container) {
-  if (game.children && game.children.length > 0) {
+  if (game.state.children && game.state.children.length > 0) {
     const choice = document.createElement('div');
     const msg = document.createElement('p');
     msg.textContent = 'Continue as one of your children:';
     choice.appendChild(msg);
-    game.children.forEach((child, i) => {
+    game.state.children.forEach((child, i) => {
       const btn = document.createElement('button');
       btn.className = 'btn block';
       const name = child.name ? child.name : `Child ${i + 1}`;

--- a/scripts/state.js
+++ b/scripts/state.js
@@ -113,7 +113,9 @@ export const game = {
   siblings: randomSiblings(),
   maritalStatus: 'single',
   spouse: null,
-  children: [],
+  state: {
+    children: []
+  },
   parents: {
     mother,
     father
@@ -156,6 +158,15 @@ export const game = {
   },
   log: []
 };
+
+Object.defineProperty(game, 'children', {
+  get() {
+    return game.state.children;
+  },
+  set(v) {
+    game.state.children = v;
+  }
+});
 
 let currentSlot = storageAvailable() ? localStorage.getItem('currentSlot') : null;
 
@@ -333,8 +344,10 @@ export function loadGame(slot = currentSlot) {
     if (typeof game.medicalBills !== 'number') {
       game.medicalBills = 0;
     }
-    if (!game.children) {
-      game.children = [];
+    if (!game.state) {
+      game.state = { children: [] };
+    } else if (!game.state.children) {
+      game.state.children = [];
     }
     if (!game.siblings) {
       game.siblings = [];
@@ -547,7 +560,7 @@ export function newLife(genderInput, nameInput, options = {}) {
 }
 
 export function continueAsChild(index) {
-  const child = game.children?.[index];
+  const child = game.state.children?.[index];
   if (!child) return;
   const name = child.name ? child.name : `Child ${index + 1}`;
   newLife(null, name, {

--- a/scripts/taskChances.js
+++ b/scripts/taskChances.js
@@ -64,6 +64,12 @@ export const taskChances = {
     spouseArgue: 80 // Chance a spouse engages in an argument
   },
 
+  // Family planning activities
+  familyPlanning: {
+    conception: 60, // Chance to conceive a child
+    care: 85 // Chance caring improves a child's traits
+  },
+
   // Travel actions
   travel: {
     emigrate: 75 // Chance emigration is approved

--- a/tests/actions.ageUp.test.js
+++ b/tests/actions.ageUp.test.js
@@ -33,6 +33,7 @@ const game = {
     mother: { age: 50, health: 80 },
     father: { age: 52, health: 80 }
   },
+  state: { children: [] },
   siblings: []
 };
 

--- a/tests/state.childContinuation.test.js
+++ b/tests/state.childContinuation.test.js
@@ -32,7 +32,7 @@ const { continueAsChild, game, lifeState } = await import('../scripts/state.js')
 
 describe('continueAsChild', () => {
   test('starts new life as existing child', () => {
-    game.children = [{ name: 'Junior', age: 7, happiness: 80 }];
+    game.state.children = [{ name: 'Junior', age: 7, happiness: 80 }];
     game.year = 1995;
     continueAsChild(0);
     expect(game.name).toBe('Junior');


### PR DESCRIPTION
## Summary
- add family planning activity with conception and child care actions
- store children under `game.state.children` and age them yearly
- introduce configurable odds for conception and care

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf03ed69f0832a845f90762076bdcb