### PR TITLE
fix: avoid crash when parents missing

### DIFF
--- a/scripts/actions/elderCare.js
+++ b/scripts/actions/elderCare.js
@@ -31,9 +31,10 @@ export function visitParent(type) {
 }
 
 export function tickParents() {
+  if (!game.parents) return;
   for (const key of ['mother', 'father']) {
     const p = game.parents[key];
-    if (p.health <= 0) continue;
+    if (!p || p.health <= 0) continue;
     p.age += 1;
     p.health = clamp(p.health - rand(1, 5));
     if (p.health <= 0) {

--- a/tests/actions.elderCare.test.js
+++ b/tests/actions.elderCare.test.js
@@ -1,0 +1,46 @@
+import { jest } from '@jest/globals';
+
+const addLog = jest.fn();
+const game = { parents: {}, money: 0 };
+const applyAndSave = (fn) => fn();
+
+const rand = jest.fn((min, max) => {
+  if (max === 5) return 5; // ensure parent dies
+  return 5000;
+});
+const clamp = (v, min = 0, max = 100) => Math.min(Math.max(v, min), max);
+
+await jest.unstable_mockModule('../scripts/state.js', () => ({
+  game,
+  addLog,
+  applyAndSave
+}));
+await jest.unstable_mockModule('../scripts/utils.js', () => ({ rand, clamp }));
+
+const { tickParents } = await import('../scripts/actions/elderCare.js');
+
+describe('tickParents', () => {
+  beforeEach(() => {
+    addLog.mockClear();
+    rand.mockClear();
+    game.money = 0;
+    game.parents = {};
+  });
+
+  test('handles missing parents gracefully', () => {
+    expect(() => tickParents()).not.toThrow();
+    expect(addLog).not.toHaveBeenCalled();
+  });
+
+  test('ages and handles parent death', () => {
+    game.parents.mother = { age: 60, health: 1 };
+    tickParents();
+    expect(game.parents.mother.age).toBe(61);
+    expect(game.money).toBe(5000);
+    expect(addLog).toHaveBeenCalledWith(
+      expect.stringContaining('mother passed away'),
+      'family'
+    );
+  });
+});
+


### PR DESCRIPTION
## Summary
- guard `tickParents` when parent records are missing
- add tests covering parent absence and inheritance logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf69782470832aaf51e5c4f5091662