### PR TITLE
Handle missing stock portfolio in tickStocks

### DIFF
--- a/scripts/economy/stocks.js
+++ b/scripts/economy/stocks.js
@@ -189,6 +189,9 @@ export function sellStock(symbol, shares) {
 }
 
 export function tickStocks() {
+  if (!game.state) game.state = {};
+  if (typeof game.state.cash !== 'number') game.state.cash = 0;
+  if (!Array.isArray(game.state.portfolio)) game.state.portfolio = [];
   let dividends = 0;
   let maturities = 0;
   for (const stock of market) {


### PR DESCRIPTION
## Summary
- Prevent TypeError when aging up without a stock portfolio
- Re-initialize stock cash and holdings when updating the market

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf71a783f0832aa3b5c8b498223fd2