### PR TITLE
docs: document car purchase process

### DIFF
--- a/documentation/buyCar.md
+++ b/documentation/buyCar.md
@@ -1,0 +1,15 @@
+# Buying a Car
+
+Buying a car deducts its purchase price from your funds and adds the vehicle to your state.
+
+## Negotiation Discount Chances
+- Each purchase checks `taskChances.cars.dealDiscount` for a 10% price cut.
+- Successful haggling logs a discount message.
+
+## Purchase Costs and Storage
+- If you cannot cover the adjusted price, the sale is denied.
+- Purchased cars are stored in `game.cars` with their final value.
+
+## Relationships to Other Systems
+- `scheduleMaintenance` services every owned car, charging up to 5% of its value.
+- Commuting with a car triggers accident checks via `checkForAccident`, making maintenance and safety important.


### PR DESCRIPTION
## Summary
- add buyCar documentation detailing discount chances, costs, and state storage
- note ties between buying cars, maintenance scheduling, and commute accident checks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4a360c640832aa3c8d4c7d3f821c8